### PR TITLE
Ajout checklist + typescript

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+- [ ] J'ai testé sur iphone
+- [ ] J'ai testé sur android
+
+- [ ] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
+  master en api)
+  - Oui parce que
+  - Non parce que
+
+- [ ] Je n'envoie pas de nouveau paramètre dans une route
+    - Si j'en envoie un nouveau, explication et gestion de la compatibilite:
+- [ ] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas
+- [ ] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas.
+- [ ] Je n'ai pas changé de constante
+
+- J'ai ajouté une variable d'environnement :
+  - [ ] Je l'ai ajouté dans env.dev et env.prod aussi
+
+- Cas d'usage :

--- a/.github/workflows/ts-lint.yml
+++ b/.github/workflows/ts-lint.yml
@@ -1,11 +1,11 @@
-name: Test ESLint
+name: Tests ESLint and Typescript
 
 on:
   - pull_request
 
 jobs:
   build:
-    name: Run ESLint
+    name: Run ESLint and Typescript tests
     runs-on: ubuntu-latest
     steps:
       
@@ -21,4 +21,4 @@ jobs:
       - run: npm ci
 
       # Run ESLint
-      - run: yarn lint
+      - run: npm run ts-lint

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "eject": "expo eject",
-    "lint": "eslint App/index.tsx --ext .js,.jsx,.ts,.tsx -c .eslintrc.js"
+    "ts-lint": "tsc --noEmit & eslint App/index.tsx --ext .js,.jsx,.ts,.tsx -c .eslintrc.js"
   },
   "dependencies": {
     "expo": "~40.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,4 +17,5 @@
     // Added options
     "typeRoots": ["./node_modules/@types"],
   },
+  "exclude": ["node_modules"],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,20 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
+    // Recommended for every project
+    "target": "ES6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    "noEmit": true /* Do not emit outputs. */,
     "jsx": "react-native",
-    "lib": ["dom", "esnext"],
-    "moduleResolution": "node",
-    "noEmit": true,
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    "allowSyntheticDefaultImports": true /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */,
+    "sourceMap": true,
+
+    // Added Rules
+    "noImplicitAny": true,
+    "strict": true /* Enable all strict type-checking options. */,
     "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "strict": true
-  }
+
+    // Added options
+    "typeRoots": ["./node_modules/@types"],
+  },
 }


### PR DESCRIPTION
Checklist : pas de changement par rapport à celle de l'app mobile formation
Typescript : quelques changements : 
 - J'ai enlevé `declaration` et `outdir` car ils permettaient de créer des fichiers alors que `noEmit` indique justement de ne pas les créer
 - j'ai passé `noImplicitAny` a true. Je me suis dit que si il etait a true cela permettrait de nous forcer à utiliser typescript au maximum. A voir si a l'usage c'est trop embetant ? 
 - J'ai enlevé `include` --> je me suis dit qu'on voulait tester tous les fichiers ? (idem a voir à l'usage)

J'ai déplacé `allowSyntheticDefaultImports` pour qu'il soit a coté de `esModuleInterop` car le fait d'avoir `esModuleInterop` met par defaut la valeur de `allowSyntheticDefaultImports` à true. Je me suis dit qu'on pouvait tout de meme conserver les deux pour que la config soit plus exhaustive. 