### PR TITLE
Com 2024

### DIFF
--- a/App/index.tsx
+++ b/App/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, StatusBar } from 'react-native';
 import AppLoading from 'expo-app-loading';
 import * as Sentry from 'sentry-expo';
@@ -8,12 +8,18 @@ import { WHITE } from '../src/styles/colors';
 import styles from './styles';
 import AppContainer from '../src/AppContainer';
 import getEnvVars from '../environment';
+import Analytics from '../src/core/helpers/analytics';
 
 const { sentryKey } = getEnvVars();
 Sentry.init({ dsn: sentryKey, debug: false });
 
 const App = () => {
   const [isAppReady, setIsAppReady] = useState<boolean>(false);
+
+  useEffect(() => {
+    async function startAnalytics() { await Analytics.logSessionStart(); }
+    startAnalytics();
+  }, []);
 
   if (!isAppReady) {
     return <AppLoading startAsync={initializeAssets} onFinish={() => setIsAppReady(true)} onError={console.error} />;

--- a/app.json
+++ b/app.json
@@ -20,9 +20,15 @@
       "checkAutomatically": "ON_LOAD",
       "fallbackToCacheTimeout": 3000
     },
-    "ios": { "icon": "./assets/images/ios_icon.png" },
+    "ios": {
+      "bundleIdentifier": "com.alenvi.compani",
+      "icon": "./assets/images/ios_icon.png",
+      "googleServicesFile": "./GoogleService-Info.plist"
+    },
     "android": {
-      "adaptiveIcon": { "foregroundImage": "./assets/images/android_icon.png" }
+      "package": "com.alenvi.compani",
+      "adaptiveIcon": { "foregroundImage": "./assets/images/android_icon.png" },
+      "googleServicesFile": "./google-services.json"
     },
     "extra": {
       "hooks": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1357,6 +1357,316 @@
         "lodash.template": "^4.5.0"
       }
     },
+    "@firebase/analytics": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.2.tgz",
+      "integrity": "sha512-4Ceov+rPfOEPIdbjlpTim/wbcUUneIesHag4UOzvmFsRRXqbxLwQpyZQWEbTSriUeU8uTKj9yOW32hsskV9Klg==",
+      "dev": true,
+      "requires": {
+        "@firebase/analytics-types": "0.4.0",
+        "@firebase/component": "0.1.21",
+        "@firebase/installations": "0.4.19",
+        "@firebase/logger": "0.2.6",
+        "@firebase/util": "0.3.4",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@firebase/analytics-types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.4.0.tgz",
+      "integrity": "sha512-Jj2xW+8+8XPfWGkv9HPv/uR+Qrmq37NPYT352wf7MvE9LrstpLVmFg3LqG6MCRr5miLAom5sen2gZ+iOhVDeRA==",
+      "dev": true
+    },
+    "@firebase/app": {
+      "version": "0.6.13",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.13.tgz",
+      "integrity": "sha512-xGrJETzvCb89VYbGSHFHCW7O/y067HRxT7MGehUE1xMxdPVBDNayHnxEuKwzfGvXAjVmajXBKFlKxaCWpgSjCQ==",
+      "dev": true,
+      "requires": {
+        "@firebase/app-types": "0.6.1",
+        "@firebase/component": "0.1.21",
+        "@firebase/logger": "0.2.6",
+        "@firebase/util": "0.3.4",
+        "dom-storage": "2.1.0",
+        "tslib": "^1.11.1",
+        "xmlhttprequest": "1.8.0"
+      }
+    },
+    "@firebase/app-types": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.1.tgz",
+      "integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg==",
+      "dev": true
+    },
+    "@firebase/auth": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.16.1.tgz",
+      "integrity": "sha512-7juD7D/kaxNti/xa5G+ZGJJs+bdJUWOW0MlNBtXwiG+TjMh69EDmwJnQmmc9h/32QVvXt1qo1OGWOoMMpF/2Gg==",
+      "dev": true,
+      "requires": {
+        "@firebase/auth-types": "0.10.1"
+      }
+    },
+    "@firebase/auth-interop-types": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.5.tgz",
+      "integrity": "sha512-88h74TMQ6wXChPA6h9Q3E1Jg6TkTHep2+k63OWg3s0ozyGVMeY+TTOti7PFPzq5RhszQPQOoCi59es4MaRvgCw==",
+      "dev": true
+    },
+    "@firebase/auth-types": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.1.tgz",
+      "integrity": "sha512-/+gBHb1O9x/YlG7inXfxff/6X3BPZt4zgBv4kql6HEmdzNQCodIRlEYnI+/da+lN+dha7PjaFH7C7ewMmfV7rw==",
+      "dev": true
+    },
+    "@firebase/component": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.21.tgz",
+      "integrity": "sha512-kd5sVmCLB95EK81Pj+yDTea8pzN2qo/1yr0ua9yVi6UgMzm6zAeih73iVUkaat96MAHy26yosMufkvd3zC4IKg==",
+      "dev": true,
+      "requires": {
+        "@firebase/util": "0.3.4",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@firebase/database": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.8.3.tgz",
+      "integrity": "sha512-i29rr3kcPltIkA8La9M1lgsSxx9bfu5lCQ0T+tbJptZ3UpqpcL1NzCcZa24cJjiLgq3HQNPyLvUvCtcPSFDlRg==",
+      "dev": true,
+      "requires": {
+        "@firebase/auth-interop-types": "0.1.5",
+        "@firebase/component": "0.1.21",
+        "@firebase/database-types": "0.6.1",
+        "@firebase/logger": "0.2.6",
+        "@firebase/util": "0.3.4",
+        "faye-websocket": "0.11.3",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@firebase/database-types": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.6.1.tgz",
+      "integrity": "sha512-JtL3FUbWG+bM59iYuphfx9WOu2Mzf0OZNaqWiQ7lJR8wBe7bS9rIm9jlBFtksB7xcya1lZSQPA/GAy2jIlMIkA==",
+      "dev": true,
+      "requires": {
+        "@firebase/app-types": "0.6.1"
+      }
+    },
+    "@firebase/firestore": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.1.2.tgz",
+      "integrity": "sha512-8yUdBLLr6UhE+IjPR+fxLBD0bDnEqF9GalohfURZeLQPaL3b+LtqqGCLvvXC4MKT0lJAHOV8J9LA6rHj8vI0/Q==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.1.21",
+        "@firebase/firestore-types": "2.1.0",
+        "@firebase/logger": "0.2.6",
+        "@firebase/util": "0.3.4",
+        "@firebase/webchannel-wrapper": "0.4.1",
+        "@grpc/grpc-js": "^1.0.0",
+        "@grpc/proto-loader": "^0.5.0",
+        "node-fetch": "2.6.1",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@firebase/firestore-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.1.0.tgz",
+      "integrity": "sha512-jietErBWihMvJkqqEquQy5GgoEwzHnMXXC/TsVoe9FPysXm1/AeJS12taS7ZYvenAtyvL/AEJyKrRKRh4adcJQ==",
+      "dev": true
+    },
+    "@firebase/functions": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.1.tgz",
+      "integrity": "sha512-xNCAY3cLlVWE8Azf+/84OjnaXMoyUstJ3vwVRG0ie22QhsdQuPa1tXTiPX4Tmm+Hbbd/Aw0A/7dkEnuW+zYzaQ==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.1.21",
+        "@firebase/functions-types": "0.4.0",
+        "@firebase/messaging-types": "0.5.0",
+        "node-fetch": "2.6.1",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@firebase/functions-types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.4.0.tgz",
+      "integrity": "sha512-3KElyO3887HNxtxNF1ytGFrNmqD+hheqjwmT3sI09FaDCuaxGbOnsXAXH2eQ049XRXw9YQpHMgYws/aUNgXVyQ==",
+      "dev": true
+    },
+    "@firebase/installations": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.19.tgz",
+      "integrity": "sha512-QqAQzosKVVqIx7oMt5ujF4NsIXgtlTnej4JXGJ8sQQuJoMnt3T+PFQRHbr7uOfVaBiHYhEaXCcmmhfKUHwKftw==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.1.21",
+        "@firebase/installations-types": "0.3.4",
+        "@firebase/util": "0.3.4",
+        "idb": "3.0.2",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@firebase/installations-types": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.3.4.tgz",
+      "integrity": "sha512-RfePJFovmdIXb6rYwtngyxuEcWnOrzdZd9m7xAW0gRxDIjBT20n3BOhjpmgRWXo/DAxRmS7bRjWAyTHY9cqN7Q==",
+      "dev": true
+    },
+    "@firebase/logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.6.tgz",
+      "integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw==",
+      "dev": true
+    },
+    "@firebase/messaging": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.3.tgz",
+      "integrity": "sha512-63nOP2SmQJrj9jrhV3K96L5MRKS6AqmFVLX1XbGk6K6lz38ZC4LIoCcHxzUBXY7fCAuZvNmh/YB3pE8B2mTs8A==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.1.21",
+        "@firebase/installations": "0.4.19",
+        "@firebase/messaging-types": "0.5.0",
+        "@firebase/util": "0.3.4",
+        "idb": "3.0.2",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@firebase/messaging-types": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-types/-/messaging-types-0.5.0.tgz",
+      "integrity": "sha512-QaaBswrU6umJYb/ZYvjR5JDSslCGOH6D9P136PhabFAHLTR4TWjsaACvbBXuvwrfCXu10DtcjMxqfhdNIB1Xfg==",
+      "dev": true
+    },
+    "@firebase/performance": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.5.tgz",
+      "integrity": "sha512-oenEOaV/UzvV8XPi8afYQ71RzyrHoBesqOyXqb1TOg7dpU+i+UJ5PS8K64DytKUHTxQl+UJFcuxNpsoy9BpWzw==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.1.21",
+        "@firebase/installations": "0.4.19",
+        "@firebase/logger": "0.2.6",
+        "@firebase/performance-types": "0.0.13",
+        "@firebase/util": "0.3.4",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@firebase/performance-types": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.0.13.tgz",
+      "integrity": "sha512-6fZfIGjQpwo9S5OzMpPyqgYAUZcFzZxHFqOyNtorDIgNXq33nlldTL/vtaUZA8iT9TT5cJlCrF/jthKU7X21EA==",
+      "dev": true
+    },
+    "@firebase/polyfill": {
+      "version": "0.3.36",
+      "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.36.tgz",
+      "integrity": "sha512-zMM9oSJgY6cT2jx3Ce9LYqb0eIpDE52meIzd/oe/y70F+v9u1LDqk5kUF5mf16zovGBWMNFmgzlsh6Wj0OsFtg==",
+      "dev": true,
+      "requires": {
+        "core-js": "3.6.5",
+        "promise-polyfill": "8.1.3",
+        "whatwg-fetch": "2.0.4"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+          "dev": true
+        },
+        "whatwg-fetch": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+          "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+          "dev": true
+        }
+      }
+    },
+    "@firebase/remote-config": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.30.tgz",
+      "integrity": "sha512-LAfLDcp1AN0V/7AkxBuTKy+Qnq9fKYKxbA5clrXRNVzJbTVnF5eFGsaUOlkes0ESG6lbqKy5ZcDgdl73zBIhAA==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.1.21",
+        "@firebase/installations": "0.4.19",
+        "@firebase/logger": "0.2.6",
+        "@firebase/remote-config-types": "0.1.9",
+        "@firebase/util": "0.3.4",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@firebase/remote-config-types": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.1.9.tgz",
+      "integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA==",
+      "dev": true
+    },
+    "@firebase/storage": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.4.2.tgz",
+      "integrity": "sha512-87CrvKrf8kijVekRBmUs8htsNz7N5X/pDhv3BvJBqw8K65GsUolpyjx0f4QJRkCRUYmh3MSkpa5P08lpVbC6nQ==",
+      "dev": true,
+      "requires": {
+        "@firebase/component": "0.1.21",
+        "@firebase/storage-types": "0.3.13",
+        "@firebase/util": "0.3.4",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@firebase/storage-types": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.3.13.tgz",
+      "integrity": "sha512-pL7b8d5kMNCCL0w9hF7pr16POyKkb3imOW7w0qYrhBnbyJTdVxMWZhb0HxCFyQWC0w3EiIFFmxoz8NTFZDEFog==",
+      "dev": true
+    },
+    "@firebase/util": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.4.tgz",
+      "integrity": "sha512-VwjJUE2Vgr2UMfH63ZtIX9Hd7x+6gayi6RUXaTqEYxSbf/JmehLmAEYSuxS/NckfzAXWeGnKclvnXVibDgpjQQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "@firebase/webchannel-wrapper": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.4.1.tgz",
+      "integrity": "sha512-0yPjzuzGMkW1GkrC8yWsiN7vt1OzkMIi9HgxRmKREZl2wnNPOKo/yScTjXf/O57HM8dltqxPF6jlNLFVtc2qdw==",
+      "dev": true
+    },
+    "@grpc/grpc-js": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.12.tgz",
+      "integrity": "sha512-+gPCklP1eqIgrNPyzddYQdt9+GvZqPlLpIjIo+TveE+gbtp74VV1A2ju8ExeO8ma8f7MbpaGZx/KJPYVWL9eDw==",
+      "dev": true,
+      "requires": {
+        "@types/node": ">=12.12.47",
+        "google-auth-library": "^6.1.1",
+        "semver": "^6.2.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "@grpc/proto-loader": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.6.tgz",
+      "integrity": "sha512-DT14xgw3PSzPxwS13auTEwxhMMOoz33DPUKNtmYK/QYbBSpLXJy78FGGs5yVoxVobEqPm4iW9MOIoz0A3bLTRQ==",
+      "dev": true,
+      "requires": {
+        "lodash.camelcase": "^4.3.0",
+        "protobufjs": "^6.8.6"
+      }
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -1887,6 +2197,70 @@
         "@nodelib/fs.scandir": "2.1.4",
         "fastq": "^1.6.0"
       }
+    },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
+      "dev": true
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "dev": true
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
+      "dev": true
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "dev": true,
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
+      "dev": true
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
+      "dev": true
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
+      "dev": true
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
+      "dev": true
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+      "dev": true
     },
     "@react-native-async-storage/async-storage": {
       "version": "1.15.3",
@@ -2891,6 +3265,12 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "@types/long": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+      "dev": true
+    },
     "@types/node": {
       "version": "14.14.41",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
@@ -3294,6 +3674,12 @@
         "function-bind": "^1.1.1"
       }
     },
+    "arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "dev": true
+    },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -3518,6 +3904,12 @@
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
       "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
     },
+    "bignumber.js": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
+      "dev": true
+    },
     "bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -3641,6 +4033,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
       "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
+      "dev": true
     },
     "buffer-fill": {
       "version": "1.0.0",
@@ -4292,10 +4690,25 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-storage": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
+      "integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q==",
+      "dev": true
+    },
     "dom-walk": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -5104,6 +5517,19 @@
         "uuid": "^3.4.0"
       }
     },
+    "expo-firebase-analytics": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/expo-firebase-analytics/-/expo-firebase-analytics-4.0.2.tgz",
+      "integrity": "sha512-XAyzRjg+ay8TTsMh9f4sS1Jmm+JwifD1L46kMJlp4mnVu6t0LvcUyoPeSGSBPQlrLn+o4a4MBGg30uWrFqKNBw==",
+      "requires": {
+        "expo-firebase-core": "~3.0.0"
+      }
+    },
+    "expo-firebase-core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/expo-firebase-core/-/expo-firebase-core-3.0.0.tgz",
+      "integrity": "sha512-cCzBl1N6cQFx98ER6rxjGkiW8OOcUHVMSciE8IRDlbJAnjGPiLBILtKr2NlvEIAYPpUzmq+CHs80WI35IOv3Uw=="
+    },
     "expo-font": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-9.1.0.tgz",
@@ -5139,6 +5565,12 @@
         "fbemitter": "^2.1.1",
         "uuid": "^3.4.0"
       }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -5326,6 +5758,12 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-text-encoding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
+      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==",
+      "dev": true
+    },
     "fastq": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
@@ -5333,6 +5771,15 @@
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
+      }
+    },
+    "faye-websocket": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+      "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+      "dev": true,
+      "requires": {
+        "websocket-driver": ">=0.5.1"
       }
     },
     "fb-watchman": {
@@ -5546,6 +5993,28 @@
         "path-exists": "^4.0.0"
       }
     },
+    "firebase": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.2.3.tgz",
+      "integrity": "sha512-WdbcGSiLxiW/kGZT+EyqD9z3Md7kR35+k9qMjDn/twiIrm6Hh7Qi/Z69cqxhKW6+4uK5ghXIF28CjK67OyD9Qw==",
+      "dev": true,
+      "requires": {
+        "@firebase/analytics": "0.6.2",
+        "@firebase/app": "0.6.13",
+        "@firebase/app-types": "0.6.1",
+        "@firebase/auth": "0.16.1",
+        "@firebase/database": "0.8.3",
+        "@firebase/firestore": "2.1.2",
+        "@firebase/functions": "0.6.1",
+        "@firebase/installations": "0.4.19",
+        "@firebase/messaging": "0.7.3",
+        "@firebase/performance": "0.4.5",
+        "@firebase/polyfill": "0.3.36",
+        "@firebase/remote-config": "0.1.30",
+        "@firebase/storage": "0.4.2",
+        "@firebase/util": "0.3.4"
+      }
+    },
     "flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -5691,6 +6160,37 @@
         }
       }
     },
+    "gaxios": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.2.0.tgz",
+      "integrity": "sha512-Ms7fNifGv0XVU+6eIyL9LB7RVESeML9+cMvkwGS70xyD6w2Z80wl6RiqiJ9k1KFlJCUTQqFFc8tXmPQfSKUe8g==",
+      "dev": true,
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.3.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        }
+      }
+    },
+    "gcp-metadata": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.2.1.tgz",
+      "integrity": "sha512-tSk+REe5iq/N+K+SK1XjZJUrFPuDqGZVzCy2vocIHIGmPlTGsa8owXMJwGkrXr73NO0AzhPW4MF2DEHz7P2AVw==",
+      "dev": true,
+      "requires": {
+        "gaxios": "^4.0.0",
+        "json-bigint": "^1.0.0"
+      }
+    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -5779,10 +6279,64 @@
         "slash": "^3.0.0"
       }
     },
+    "google-auth-library": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
+      "integrity": "sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==",
+      "dev": true,
+      "requires": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^4.0.0",
+        "gcp-metadata": "^4.2.0",
+        "gtoken": "^5.0.4",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "google-p12-pem": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
+      "integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
+      "dev": true,
+      "requires": {
+        "node-forge": "^0.10.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+    },
+    "gtoken": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.1.tgz",
+      "integrity": "sha512-OY0BfPKe3QnMsY9MzTHTSKn+Vl2l1CcLe6BwDEQj00mbbkl5nyQ/7EUREstg4fQNZ8iYE7br4JJ7TdKeDOPWmw==",
+      "dev": true,
+      "requires": {
+        "gaxios": "^4.0.0",
+        "google-p12-pem": "^3.0.3",
+        "jws": "^4.0.0"
+      }
     },
     "has": {
       "version": "1.0.3",
@@ -5887,6 +6441,12 @@
         "toidentifier": "1.0.0"
       }
     },
+    "http-parser-js": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
+      "integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==",
+      "dev": true
+    },
     "https-proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
@@ -5908,6 +6468,12 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
+    },
+    "idb": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-3.0.2.tgz",
+      "integrity": "sha512-+FLa/0sTXqyux0o6C+i2lOR0VoS60LU/jzUo5xjfY6+7sEEgy4Gz1O7yFBXvjd7N0NyIGWIRg8DcQSLEG+VSPw==",
+      "dev": true
     },
     "ieee754": {
       "version": "1.2.1",
@@ -6737,6 +7303,15 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
+    "json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "requires": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -6799,6 +7374,27 @@
       "requires": {
         "array-includes": "^3.1.2",
         "object.assign": "^4.1.2"
+      }
+    },
+    "jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "dev": true,
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "dev": true,
+      "requires": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "kind-of": {
@@ -6922,6 +7518,12 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -7026,6 +7628,12 @@
         "dayjs": "^1.8.15",
         "yargs": "^15.1.0"
       }
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -7891,6 +8499,12 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
+    "node-forge": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "dev": true
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -8628,6 +9242,12 @@
         "asap": "~2.0.3"
       }
     },
+    "promise-polyfill": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
+      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
+      "dev": true
+    },
     "prop-types": {
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
@@ -8636,6 +9256,35 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.8.1"
+      }
+    },
+    "protobufjs": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.2.tgz",
+      "integrity": "sha512-27yj+04uF6ya9l+qfpH187aqEzfCF4+Uit0I9ZBQVqK09hk/SQzKa2MUqUpXaVa7LOFRg1TSSr3lVxGOk6c0SQ==",
+      "dev": true,
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": "^13.7.0",
+        "long": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.50",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.50.tgz",
+          "integrity": "sha512-y7kkh+hX/0jZNxMyBR/6asG0QMSaPSzgeVK63dhWHl4QAXCQB8lExXmzLL6SzmOgKHydtawpMnNhlDbv7DXPEA==",
+          "dev": true
+        }
       }
     },
     "proxy-from-env": {
@@ -10720,6 +11369,23 @@
         "defaults": "^1.0.3"
       }
     },
+    "websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "dev": true,
+      "requires": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "dev": true
+    },
     "whatwg-fetch": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
@@ -10956,6 +11622,12 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
       "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
+      "dev": true
     },
     "xpipe": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "~3.0.0",
     "react-native-web": "~0.13.12",
-    "sentry-expo": "^3.1.0"
+    "sentry-expo": "^3.1.0",
+    "expo-firebase-analytics": "~4.0.2"
   },
   "devDependencies": {
     "@babel/core": "~7.9.0",
@@ -40,6 +41,7 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-react": "^7.23.1",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "firebase": "8.2.3",
     "typescript": "~4.0.0"
   },
   "private": true

--- a/src/AppNavigation/index.tsx
+++ b/src/AppNavigation/index.tsx
@@ -18,7 +18,9 @@ const AppNavigation = () => {
   useEffect(() => { tryLocalSignIn(); }, []);
 
   const handleOnReadyNavigation = () => {
-    routeNameRef.current = navigationRef.current?.getCurrentRoute()?.name;
+    const currentRouteName = navigationRef.current?.getCurrentRoute()?.name || '';
+    routeNameRef.current = currentRouteName;
+    Analytics.logScreenView(currentRouteName);
   };
 
   const handleNavigationStateChange = () => {

--- a/src/core/helpers/analytics.ts
+++ b/src/core/helpers/analytics.ts
@@ -1,0 +1,19 @@
+import * as Analytics from 'expo-firebase-analytics';
+
+const logSessionStart = async () => Analytics.logEvent('session_start');
+
+const logScreenView = (screen: string) => Analytics.logEvent(
+  'screen_view',
+  {
+    screen_name: screen,
+    screen_class: screen,
+    page_title: screen,
+    firebase_screen_class: screen,
+    firebase_screen: screen,
+  }
+);
+
+export default {
+  logSessionStart,
+  logScreenView,
+};


### PR DESCRIPTION
Ajout de Firebase : ouverture de l'application + enregistrement des differents ecrans 
--> Pour pouvoir afficher sur firebase uniquement les infos de l'app erp sur expo go : filtrer par flux ERP 

Il y a un warning sur `Constant.installationId` du au passage au sdk 41 car cela a ete deprecie. J'ai prefere ne pas faire de fix pour l'instant: 
- InstallationId est deprecie mais pas encore supprime (seulement au sdk 44), du coup je me dis que si expo-firebase-analytics le fix, c'est mieux de prendre leur solution
- J'ai l'impression que ca ne gene pas l'utilisation de firebase
- Je crois comprendre que ce n'est que pour expo go (donc pas en prod) https://docs.expo.io/versions/latest/sdk/firebase-analytics/#setclientid

Qu'en pensez-vous ? 