### PR TITLE
Com 2016 use axios

### DIFF
--- a/src/AppContainer/index.tsx
+++ b/src/AppContainer/index.tsx
@@ -10,7 +10,7 @@ import { useAxios } from '../hooks/useAxios';
 
 const AppContainer = () => {
   const [updateAppVisible, setUpdateAppVisible] = useState<boolean>(false);
-  const { maintenanceModale } = useContext(AuthContext);
+  const { maintenanceModal } = useContext(AuthContext);
   const { callApi } = useAxios();
 
   const shouldUpdate = useCallback(async (nextState: string) => {
@@ -34,7 +34,7 @@ const AppContainer = () => {
 
   return (
     <>
-      <MaintenanceModal visible={maintenanceModale} />
+      <MaintenanceModal visible={maintenanceModal} />
       <UpdateAppModal visible={updateAppVisible} />
       <AppNavigation />
     </>

--- a/src/AppContainer/index.tsx
+++ b/src/AppContainer/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useContext } from 'react';
+import React, { useEffect, useState, useContext, useCallback } from 'react';
 import { AppState } from 'react-native';
 import Version from '../api/Versions';
 import { ACTIVE_STATE } from '../core/data/constants';
@@ -13,7 +13,7 @@ const AppContainer = () => {
   const { maintenanceModale } = useContext(AuthContext);
   const { callApi } = useAxios();
 
-  const shouldUpdate = async (nextState: string) => {
+  const shouldUpdate = useCallback(async (nextState: string) => {
     try {
       if (nextState === ACTIVE_STATE) {
         const { mustUpdate } = await callApi(Version.shouldUpdate());
@@ -23,14 +23,14 @@ const AppContainer = () => {
       setUpdateAppVisible(false);
       console.error(e);
     }
-  };
+  }, [callApi]);
 
   useEffect(() => {
     shouldUpdate(ACTIVE_STATE);
     AppState.addEventListener('change', shouldUpdate);
 
     return () => { AppState.removeEventListener('change', shouldUpdate); };
-  }, []);
+  }, [shouldUpdate]);
 
   return (
     <>

--- a/src/AppContainer/index.tsx
+++ b/src/AppContainer/index.tsx
@@ -18,10 +18,10 @@ const AppContainer = () => {
         setMaintenanceModalVisible(false);
         return response;
       },
-      async (error) => {
-        if ([502, 503].includes(error.response.status)) setMaintenanceModalVisible(true);
-        return Promise.reject(error.response);
-      }
+      async error =>
+        // if ([502, 503].includes(error.response.status)) setMaintenanceModalVisible(true);
+        Promise.reject(error.response)
+
     );
 
     setAxiosInitialized(true);

--- a/src/AppContainer/index.tsx
+++ b/src/AppContainer/index.tsx
@@ -9,7 +9,7 @@ import { Context as AuthContext } from '../context/AuthContext';
 import { useAxios } from '../hooks/useAxios';
 
 const AppContainer = () => {
-  const [updateAppVisible, setUpdateAppVisible] = useState<boolean>(false);
+  const [updateAppModal, setUpdateAppModal] = useState<boolean>(false);
   const { maintenanceModal } = useContext(AuthContext);
   const { callApi } = useAxios();
 
@@ -17,10 +17,10 @@ const AppContainer = () => {
     try {
       if (nextState === ACTIVE_STATE) {
         const { mustUpdate } = await callApi(Version.shouldUpdate());
-        setUpdateAppVisible(mustUpdate);
+        setUpdateAppModal(mustUpdate);
       }
     } catch (e) {
-      setUpdateAppVisible(false);
+      setUpdateAppModal(false);
       console.error(e);
     }
   }, [callApi]);
@@ -35,7 +35,7 @@ const AppContainer = () => {
   return (
     <>
       <MaintenanceModal visible={maintenanceModal} />
-      <UpdateAppModal visible={updateAppVisible} />
+      <UpdateAppModal visible={updateAppModal} />
       <AppNavigation />
     </>
   );

--- a/src/api/Users.ts
+++ b/src/api/Users.ts
@@ -1,11 +1,9 @@
-import { AxiosInstance } from 'axios';
 import getEnvVars from '../../environment';
 
 export default {
-  exists: async (axios: AxiosInstance, params: { email: string }) => {
+  exists: (params: { email: string }) => {
     const { baseURL } = getEnvVars();
-    console.log('custom axios', axios);
-    const exists = await axios.get(`${baseURL}/users/exists`, { params });
-    return exists.data.data.exists;
+
+    return { method: 'GET', url: `${baseURL}/users/exists`, params };
   },
 };

--- a/src/api/Users.ts
+++ b/src/api/Users.ts
@@ -1,9 +1,10 @@
-import axios from 'axios';
+import { AxiosInstance } from 'axios';
 import getEnvVars from '../../environment';
 
 export default {
-  exists: async (params: { email: string }) => {
+  exists: async (axios: AxiosInstance, params: { email: string }) => {
     const { baseURL } = getEnvVars();
+    console.log('custom axios', axios);
     const exists = await axios.get(`${baseURL}/users/exists`, { params });
     return exists.data.data.exists;
   },

--- a/src/api/Versions.ts
+++ b/src/api/Versions.ts
@@ -1,14 +1,15 @@
-import axios from 'axios';
 import Constants from 'expo-constants';
 import getEnvVars from '../../environment';
 import { ERP } from '../core/data/constants';
 
 export default {
-  shouldUpdate: async () => {
+  shouldUpdate: () => {
     const { baseURL } = getEnvVars();
-    const params = { mobileVersion: Constants.manifest.version, appName: ERP };
 
-    const response = await axios.get(`${baseURL}/version/should-update`, { params });
-    return response.data.data;
+    return {
+      method: 'GET',
+      url: `${baseURL}/version/should-update`,
+      params: { mobileVersion: Constants.manifest.version, appName: ERP },
+    };
   },
 };

--- a/src/context/AuthContext.ts
+++ b/src/context/AuthContext.ts
@@ -11,6 +11,8 @@ const authReducer = (state: StateType, action: ActionType) => {
       return { ...state, alenviToken: null };
     case 'render':
       return { ...state, appIsReady: true };
+    case 'maintenance':
+      return { ...state, maintenanceModale: action.payload };
     default:
       return state;
   }
@@ -56,14 +58,20 @@ const tryLocalSignIn = (dispatch: React.Dispatch<ActionType>) => async () => {
   dispatch({ type: 'render' });
 };
 
+const setMaintenanceModal = (dispatch: React.Dispatch<ActionType>) => async (maintenanceModal: boolean) => {
+  dispatch({ type: 'maintenance', payload: maintenanceModal });
+};
+
 export const { Provider, Context } = createAuthContext(
   authReducer,
-  { signIn, tryLocalSignIn, signOut },
+  { signIn, tryLocalSignIn, signOut, setMaintenanceModal },
   {
     alenviToken: null,
     appIsReady: false,
+    maintenanceModale: false,
     signIn: async () => {},
     tryLocalSignIn: async () => {},
     signOut: async () => {},
+    setMaintenanceModal: async () => {},
   }
 );

--- a/src/context/AuthContext.ts
+++ b/src/context/AuthContext.ts
@@ -12,7 +12,7 @@ const authReducer = (state: StateType, action: ActionType) => {
     case 'render':
       return { ...state, appIsReady: true };
     case 'maintenance':
-      return { ...state, maintenanceModale: action.payload };
+      return { ...state, maintenanceModal: action.payload };
     default:
       return state;
   }
@@ -68,7 +68,7 @@ export const { Provider, Context } = createAuthContext(
   {
     alenviToken: null,
     appIsReady: false,
-    maintenanceModale: false,
+    maintenanceModal: false,
     signIn: async () => {},
     tryLocalSignIn: async () => {},
     signOut: async () => {},

--- a/src/context/createAuthContext.tsx
+++ b/src/context/createAuthContext.tsx
@@ -5,9 +5,11 @@ export type boundFunctionsType = (payload?: any) => Promise<void>;
 export interface StateType {
   alenviToken: string | null,
   appIsReady: boolean,
+  maintenanceModale: boolean,
   signIn: boundFunctionsType,
   signOut: boundFunctionsType,
   tryLocalSignIn: boundFunctionsType,
+  setMaintenanceModal: boundFunctionsType,
 }
 
 export interface ActionType {
@@ -28,8 +30,8 @@ export default (
   defaultValue: StateType
 ): createAuthContextType => {
   const Provider = ({ children }: {children: React.ReactNode}) => {
-    const [{ alenviToken, appIsReady }, dispatch] = useReducer(reducer, defaultValue);
-    const state = { alenviToken, appIsReady };
+    const [{ alenviToken, appIsReady, maintenanceModale }, dispatch] = useReducer(reducer, defaultValue);
+    const state = { alenviToken, appIsReady, maintenanceModale };
 
     const boundFunctions: any = {};
     // eslint-disable-next-line guard-for-in, no-restricted-syntax

--- a/src/context/createAuthContext.tsx
+++ b/src/context/createAuthContext.tsx
@@ -5,7 +5,7 @@ export type boundFunctionsType = (payload?: any) => Promise<void>;
 export interface StateType {
   alenviToken: string | null,
   appIsReady: boolean,
-  maintenanceModale: boolean,
+  maintenanceModal: boolean,
   signIn: boundFunctionsType,
   signOut: boundFunctionsType,
   tryLocalSignIn: boundFunctionsType,
@@ -30,8 +30,8 @@ export default (
   defaultValue: StateType
 ): createAuthContextType => {
   const Provider = ({ children }: {children: React.ReactNode}) => {
-    const [{ alenviToken, appIsReady, maintenanceModale }, dispatch] = useReducer(reducer, defaultValue);
-    const state = { alenviToken, appIsReady, maintenanceModale };
+    const [{ alenviToken, appIsReady, maintenanceModal }, dispatch] = useReducer(reducer, defaultValue);
+    const state = { alenviToken, appIsReady, maintenanceModal };
 
     const boundFunctions: any = {};
     // eslint-disable-next-line guard-for-in, no-restricted-syntax

--- a/src/hooks/useAxios.ts
+++ b/src/hooks/useAxios.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
-import { useContext, useEffect, useRef } from 'react';
+import { useCallback, useContext, useEffect, useRef } from 'react';
 import { Context as AuthContext } from '../context/AuthContext';
 
 export const useAxios = () => {
@@ -23,13 +23,13 @@ export const useAxios = () => {
     axiosRef.current = instance;
   }, [setMaintenanceModal]);
 
-  const callApi = async (call: object) => {
+  const callApi = useCallback(async (call: object) => {
     if (!axiosRef.current) return null;
 
     const res = await axiosRef.current(call);
 
     return res.data.data;
-  };
+  }, []);
 
   return { callApi };
 };

--- a/src/hooks/useAxios.ts
+++ b/src/hooks/useAxios.ts
@@ -1,19 +1,35 @@
 import axios, { AxiosInstance } from 'axios';
-import { useEffect, useRef } from 'react';
+import { useContext, useEffect, useRef } from 'react';
+import { Context as AuthContext } from '../context/AuthContext';
 
 export const useAxios = () => {
-  const toto = useRef<AxiosInstance | null>(null);
+  const axiosRef = useRef<AxiosInstance | null>(null);
+  const { setMaintenanceModal } = useContext(AuthContext);
 
   useEffect(() => {
     const instance = axios.create();
 
     instance.interceptors.response.use(
-      response => response,
-      async error => Promise.reject(error.response)
+      (response) => {
+        setMaintenanceModal(false);
+        return response;
+      },
+      async (error) => {
+        if ([502, 503].includes(error.response.status)) setMaintenanceModal(true);
+        return Promise.reject(error.response);
+      }
     );
 
-    toto.current = instance;
-  }, []);
+    axiosRef.current = instance;
+  }, [setMaintenanceModal]);
 
-  return { toto };
+  const callApi = async (call: object) => {
+    if (!axiosRef.current) return null;
+
+    const res = await axiosRef.current(call);
+
+    return res.data.data;
+  };
+
+  return { callApi };
 };

--- a/src/hooks/useAxios.ts
+++ b/src/hooks/useAxios.ts
@@ -1,0 +1,19 @@
+import axios, { AxiosInstance } from 'axios';
+import { useEffect, useRef } from 'react';
+
+export const useAxios = () => {
+  const toto = useRef<AxiosInstance | null>(null);
+
+  useEffect(() => {
+    const instance = axios.create();
+
+    instance.interceptors.response.use(
+      response => response,
+      async error => Promise.reject(error.response)
+    );
+
+    toto.current = instance;
+  }, []);
+
+  return { toto };
+};

--- a/src/screens/ForgotPassword/index.tsx
+++ b/src/screens/ForgotPassword/index.tsx
@@ -11,6 +11,7 @@ import { ICON } from '../../styles/metrics';
 import { GREY } from '../../styles/colors';
 import { NavigationType } from '../../types/NavigationType';
 import styles from './styles';
+import { useAxios } from '../../hooks/useAxios';
 
 interface EmailFormProps {
   navigation: NavigationType,
@@ -24,6 +25,7 @@ const ForgotPassword = ({ navigation }: EmailFormProps) => {
   const [isValidationAttempted, setIsValidationAttempted] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [forgotPasswordModal, setForgotPasswordModal] = useState<boolean>(false);
+  const { toto } = useAxios();
 
   const hardwareBackPress = useCallback(() => {
     if (!isLoading) setExitConfirmationModal(true);
@@ -52,7 +54,8 @@ const ForgotPassword = ({ navigation }: EmailFormProps) => {
     try {
       if (!invalidEmail) {
         setIsLoading(true);
-        const exists = await Users.exists({ email });
+        if (!toto.current) return;
+        const exists = await Users.exists(toto.current, { email });
         if (!exists) setErrorMessage('Oups ! Cet e-mail n\'est pas reconnu.');
         else setForgotPasswordModal(true);
       }

--- a/src/screens/ForgotPassword/index.tsx
+++ b/src/screens/ForgotPassword/index.tsx
@@ -25,7 +25,7 @@ const ForgotPassword = ({ navigation }: EmailFormProps) => {
   const [isValidationAttempted, setIsValidationAttempted] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [forgotPasswordModal, setForgotPasswordModal] = useState<boolean>(false);
-  const { toto } = useAxios();
+  const { callApi } = useAxios();
 
   const hardwareBackPress = useCallback(() => {
     if (!isLoading) setExitConfirmationModal(true);
@@ -54,8 +54,7 @@ const ForgotPassword = ({ navigation }: EmailFormProps) => {
     try {
       if (!invalidEmail) {
         setIsLoading(true);
-        if (!toto.current) return;
-        const exists = await Users.exists(toto.current, { email });
+        const { exists } = await callApi(Users.exists({ email }));
         if (!exists) setErrorMessage('Oups ! Cet e-mail n\'est pas reconnu.');
         else setForgotPasswordModal(true);
       }


### PR DESCRIPTION
C'est un proposition pour gérer nos appels à axios avec les intercepteurs. 
L'idée si on continue dans cette voie serait de créer `useCompaniAxios` pour gérer les appels qui nécessite d’être connecté

**Qu'en pensez vous ?**

Je n'ai changé que 2 routes: 
- celle coté mot de passe oublié pour savoir si l'email est relié a un compte existant
- celle pour vérifier s'il faut mettre a jour l'application
Je changerai les autres routes une fois qu'on se sera mis d'accord sur la bonne solution 