### PR TITLE
Com 2056 - npm update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2719,6 +2719,7 @@
     },
     "@sentry/browser": {
 <<<<<<< HEAD
+<<<<<<< HEAD
       "version": "6.3.3",
       "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.3.3.tgz",
       "integrity": "sha512-M3l4xdpU4fTNERnuXZ46ceMa+bAMdUOaSYbmflYt5GSkBuYS/eC8nAaCj//4CMT4JMwT3oUKYI5k6wDIKgyKMQ==",
@@ -2735,6 +2736,15 @@
         "@sentry/types": "6.3.1",
         "@sentry/utils": "6.3.1",
 >>>>>>> COM-2056 - update babel/core and breaking changes in type/react
+=======
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.3.2.tgz",
+      "integrity": "sha512-j0uo20C7Zrv1C8RAfwkZYV5uxDu34Ann+g7HiJ7LEjYBRFqb3as3nAzi7wh+0yCoDqBmxDiELRAObsTtsvxabw==",
+      "requires": {
+        "@sentry/core": "6.3.2",
+        "@sentry/types": "6.3.2",
+        "@sentry/utils": "6.3.2",
+>>>>>>> COM-2056 - update typescript
         "tslib": "^1.9.3"
       }
     },
@@ -2752,6 +2762,7 @@
       }
     },
     "@sentry/core": {
+<<<<<<< HEAD
 <<<<<<< HEAD
       "version": "6.3.3",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.3.3.tgz",
@@ -2771,10 +2782,21 @@
         "@sentry/types": "6.3.1",
         "@sentry/utils": "6.3.1",
 >>>>>>> COM-2056 - update babel/core and breaking changes in type/react
+=======
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.3.2.tgz",
+      "integrity": "sha512-Qag3Tcj6jVNh3wPsuFvIKo3sv3W6TprciTrHYu0vHWB5CLc2Ajq1y05Ac/DwT+tw6/PoJ7l3iTl7rK+lDWP9jg==",
+      "requires": {
+        "@sentry/hub": "6.3.2",
+        "@sentry/minimal": "6.3.2",
+        "@sentry/types": "6.3.2",
+        "@sentry/utils": "6.3.2",
+>>>>>>> COM-2056 - update typescript
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
+<<<<<<< HEAD
 <<<<<<< HEAD
       "version": "6.3.3",
       "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.3.3.tgz",
@@ -2790,10 +2812,19 @@
         "@sentry/types": "6.3.1",
         "@sentry/utils": "6.3.1",
 >>>>>>> COM-2056 - update babel/core and breaking changes in type/react
+=======
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.3.2.tgz",
+      "integrity": "sha512-HClMNBj365SXE2WeRq6lO8HJwztkmml7Ep4lZ09opKLzo37DK4iVWfiqQPpFSXVp89XmmrHTixE8Q+mmCqOelQ==",
+      "requires": {
+        "@sentry/types": "6.3.2",
+        "@sentry/utils": "6.3.2",
+>>>>>>> COM-2056 - update typescript
         "tslib": "^1.9.3"
       }
     },
     "@sentry/integrations": {
+<<<<<<< HEAD
 <<<<<<< HEAD
       "version": "6.3.3",
       "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.3.3.tgz",
@@ -2809,11 +2840,20 @@
         "@sentry/types": "6.3.1",
         "@sentry/utils": "6.3.1",
 >>>>>>> COM-2056 - update babel/core and breaking changes in type/react
+=======
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.3.2.tgz",
+      "integrity": "sha512-NGdPsnPXOLXgOsRD7bnzUsFhVYocex7DhvnZqBqaTWN4qkZEVX417HhtHhTys4cfWh47hg5ev9Q73j8Av71emw==",
+      "requires": {
+        "@sentry/types": "6.3.2",
+        "@sentry/utils": "6.3.2",
+>>>>>>> COM-2056 - update typescript
         "localforage": "^1.8.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
+<<<<<<< HEAD
 <<<<<<< HEAD
       "version": "6.3.3",
       "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.3.3.tgz",
@@ -2829,6 +2869,14 @@
         "@sentry/hub": "6.3.1",
         "@sentry/types": "6.3.1",
 >>>>>>> COM-2056 - update babel/core and breaking changes in type/react
+=======
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.3.2.tgz",
+      "integrity": "sha512-AZsom90oPEwQTRNzkXgdwu5BN1gNbI+AkBnKA26O8Ysm4JSpGlo5OcYHBPzrkNc8CS2F6sQwG6lRUj1Nl1KBgw==",
+      "requires": {
+        "@sentry/hub": "6.3.2",
+        "@sentry/types": "6.3.2",
+>>>>>>> COM-2056 - update typescript
         "tslib": "^1.9.3"
       }
     },
@@ -3040,6 +3088,7 @@
     },
     "@sentry/types": {
 <<<<<<< HEAD
+<<<<<<< HEAD
       "version": "6.3.3",
       "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.3.tgz",
       "integrity": "sha512-UPHzhwqdjta7LCFfqNvJ5g79lRiXOxtgnIp7zlBkHU6yZs4fPnlBadljyi2gGFguN+C+XAukrbXUAq2mb+Mhdw=="
@@ -3054,14 +3103,23 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.1.tgz",
       "integrity": "sha512-BEBn8JX1yaooCAuonbaMci9z0RjwwMbQ3Eny/eyDdd+rjXprZCZaStZnCvSThbNBqAJ8YaUqY2YBMnEwJxarAw=="
+=======
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.2.tgz",
+      "integrity": "sha512-LtVhKQABar7WhXyj/FM9v7bsIqDfDHhQkTA6saHHIIpvfJsCzaoORZD98tqxuV/6+bxT8LvncK6+XZ44spFtrA=="
+>>>>>>> COM-2056 - update typescript
     },
     "@sentry/utils": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.3.1.tgz",
-      "integrity": "sha512-cdtl/QWC9FtinAuW3w8QfvSfh/Q9ui5vwvjzVHiS1ga/U38edi2XX+cttY39ZYwz0SQG99cE10GOIhd1p7/mAA==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.3.2.tgz",
+      "integrity": "sha512-R2A5tdcGhkqrEndw5FAwz64Ndd0S529ps+OQggxjKEnhSPTs7vLBhXPE1D8nIInp/tNP2zaXlGJ1xOAqWN/gOg==",
       "requires": {
+<<<<<<< HEAD
         "@sentry/types": "6.3.1",
 >>>>>>> COM-2056 - update babel/core and breaking changes in type/react
+=======
+        "@sentry/types": "6.3.2",
+>>>>>>> COM-2056 - update typescript
         "tslib": "^1.9.3"
       }
     },
@@ -9288,9 +9346,9 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "react": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-      "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -9314,9 +9372,9 @@
       }
     },
     "react-dom": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
-      "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -11066,9 +11124,9 @@
       }
     },
     "typescript": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.7.tgz",
-      "integrity": "sha512-yi7M4y74SWvYbnazbn8/bmJmX4Zlej39ZOqwG/8dut/MYoSQ119GY9ZFbbGsD4PFZYWxqik/XsP3vk3+W5H3og==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,32 +16,31 @@
       "integrity": "sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA=="
     },
     "@babel/core": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
-      "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+      "version": "7.13.16",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.16.tgz",
+      "integrity": "sha512-sXHpixBiWWFti0AV2Zq7avpTasr6sIAu7Y396c608541qAU2ui4a193m0KSQmfPSKFZLnQ3cvlKDOm3XkuXm3Q==",
       "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.9.0",
-        "@babel/helper-module-transforms": "^7.9.0",
-        "@babel/helpers": "^7.9.0",
-        "@babel/parser": "^7.9.0",
-        "@babel/template": "^7.8.6",
-        "@babel/traverse": "^7.9.0",
-        "@babel/types": "^7.9.0",
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.13.16",
+        "@babel/helper-compilation-targets": "^7.13.16",
+        "@babel/helper-module-transforms": "^7.13.14",
+        "@babel/helpers": "^7.13.16",
+        "@babel/parser": "^7.13.16",
+        "@babel/template": "^7.12.13",
+        "@babel/traverse": "^7.13.15",
+        "@babel/types": "^7.13.16",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.1",
+        "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
-        "lodash": "^4.17.13",
-        "resolve": "^1.3.2",
-        "semver": "^5.4.1",
+        "semver": "^6.3.0",
         "source-map": "^0.5.0"
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -1216,6 +1215,38 @@
         "resolve-from": "^5.0.0",
         "semver": "7.3.2",
         "slugify": "^1.3.4"
+      },
+      "dependencies": {
+        "@babel/core": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
+          "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@babel/generator": "^7.9.0",
+            "@babel/helper-module-transforms": "^7.9.0",
+            "@babel/helpers": "^7.9.0",
+            "@babel/parser": "^7.9.0",
+            "@babel/template": "^7.8.6",
+            "@babel/traverse": "^7.9.0",
+            "@babel/types": "^7.9.0",
+            "convert-source-map": "^1.7.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.1",
+            "json5": "^2.1.2",
+            "lodash": "^4.17.13",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+            }
+          }
+        }
       }
     },
     "@expo/config-plugins": {
@@ -2687,6 +2718,7 @@
       }
     },
     "@sentry/browser": {
+<<<<<<< HEAD
       "version": "6.3.3",
       "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.3.3.tgz",
       "integrity": "sha512-M3l4xdpU4fTNERnuXZ46ceMa+bAMdUOaSYbmflYt5GSkBuYS/eC8nAaCj//4CMT4JMwT3oUKYI5k6wDIKgyKMQ==",
@@ -2694,6 +2726,15 @@
         "@sentry/core": "6.3.3",
         "@sentry/types": "6.3.3",
         "@sentry/utils": "6.3.3",
+=======
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.3.1.tgz",
+      "integrity": "sha512-Ri4tYsyuJIeLQnvQUqbpGzailUYpbjFSYM0+yEM63gPsjiXdg+W8yKHluA6cs6FLWVN3oWfwHW7Kd61echlGuw==",
+      "requires": {
+        "@sentry/core": "6.3.1",
+        "@sentry/types": "6.3.1",
+        "@sentry/utils": "6.3.1",
+>>>>>>> COM-2056 - update babel/core and breaking changes in type/react
         "tslib": "^1.9.3"
       }
     },
@@ -2711,6 +2752,7 @@
       }
     },
     "@sentry/core": {
+<<<<<<< HEAD
       "version": "6.3.3",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.3.3.tgz",
       "integrity": "sha512-wbmXmhWHpbFLmXf9DBUOp9H5Ao+T8Ztn5KXoxDwBnsYXtgVIzQfdpRbtcNtvJJ/UPZ3H3rRHQ8zQTb5Ni99xYQ==",
@@ -2719,37 +2761,74 @@
         "@sentry/minimal": "6.3.3",
         "@sentry/types": "6.3.3",
         "@sentry/utils": "6.3.3",
+=======
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-aVuvVbaehGeN86jZlLDGGkhEtprdOtB6lvYLfGy40Dj1Tkh2mGWE550QsRXAXAqYvQzIYwQR23r6m3o8FujgVg==",
+      "requires": {
+        "@sentry/hub": "6.3.1",
+        "@sentry/minimal": "6.3.1",
+        "@sentry/types": "6.3.1",
+        "@sentry/utils": "6.3.1",
+>>>>>>> COM-2056 - update babel/core and breaking changes in type/react
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
+<<<<<<< HEAD
       "version": "6.3.3",
       "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.3.3.tgz",
       "integrity": "sha512-vrJHrDKTCAL63dkNNll18Q1c7YjuIYYv5jY56RNUQpm+7sX4v+iw9giOI+iLbPKaGpEyraa17FeF/xO0SqIp9Q==",
       "requires": {
         "@sentry/types": "6.3.3",
         "@sentry/utils": "6.3.3",
+=======
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.3.1.tgz",
+      "integrity": "sha512-2er+OeVlsdVZkhl9kXQAANwgjwoCdM1etK2iFuhzX8xkMaJlAuZLyQInv2U1BbXBlIfWjvzRM8B95hCWvVrR3Q==",
+      "requires": {
+        "@sentry/types": "6.3.1",
+        "@sentry/utils": "6.3.1",
+>>>>>>> COM-2056 - update babel/core and breaking changes in type/react
         "tslib": "^1.9.3"
       }
     },
     "@sentry/integrations": {
+<<<<<<< HEAD
       "version": "6.3.3",
       "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.3.3.tgz",
       "integrity": "sha512-cAqUWfZvSLqTeNl6/9OL5dq3CJkLjVRmbG7ksvpKF1jqSHWiCk5tTmFEL+KI6gv2jqt9HBOfSr6JDGsfTPpX0w==",
       "requires": {
         "@sentry/types": "6.3.3",
         "@sentry/utils": "6.3.3",
+=======
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.3.1.tgz",
+      "integrity": "sha512-fB0+CmU2L2VJ8WyI33t060lxpBNAoh092jzMGEnnfPKTVMxnscjFrISzrWXQZs/OoR6q8Yo/+pZAT5gWA0dDOQ==",
+      "requires": {
+        "@sentry/types": "6.3.1",
+        "@sentry/utils": "6.3.1",
+>>>>>>> COM-2056 - update babel/core and breaking changes in type/react
         "localforage": "^1.8.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
+<<<<<<< HEAD
       "version": "6.3.3",
       "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.3.3.tgz",
       "integrity": "sha512-MKspEQ5hhTMrbeiNvkRGgm/NX2gM/Mni0vDJjuqQFi2Cd3RwA4ZVO6yRr6XzFPtTGgDsrXg75lQ8rma96Qs8/g==",
       "requires": {
         "@sentry/hub": "6.3.3",
         "@sentry/types": "6.3.3",
+=======
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.3.1.tgz",
+      "integrity": "sha512-0eN9S7HvXsCQEjX/qXHTMgvSb3mwrnZEWS9Qz/Bz5ig9pEGXKgJ1om5NTTHVHhXqd3wFCjdvIo6slufLHoCtSw==",
+      "requires": {
+        "@sentry/hub": "6.3.1",
+        "@sentry/types": "6.3.1",
+>>>>>>> COM-2056 - update babel/core and breaking changes in type/react
         "tslib": "^1.9.3"
       }
     },
@@ -2960,6 +3039,7 @@
       }
     },
     "@sentry/types": {
+<<<<<<< HEAD
       "version": "6.3.3",
       "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.3.tgz",
       "integrity": "sha512-UPHzhwqdjta7LCFfqNvJ5g79lRiXOxtgnIp7zlBkHU6yZs4fPnlBadljyi2gGFguN+C+XAukrbXUAq2mb+Mhdw=="
@@ -2970,6 +3050,18 @@
       "integrity": "sha512-Kz546LeF6Ff/FU53XUVaairMQYFc6sIHBvE5ReZmfDRpaR+qZnfIbWhfoIbSwyBbtF+T8/gcU7mcZpZQmM5jLw==",
       "requires": {
         "@sentry/types": "6.3.3",
+=======
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.1.tgz",
+      "integrity": "sha512-BEBn8JX1yaooCAuonbaMci9z0RjwwMbQ3Eny/eyDdd+rjXprZCZaStZnCvSThbNBqAJ8YaUqY2YBMnEwJxarAw=="
+    },
+    "@sentry/utils": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.3.1.tgz",
+      "integrity": "sha512-cdtl/QWC9FtinAuW3w8QfvSfh/Q9ui5vwvjzVHiS1ga/U38edi2XX+cttY39ZYwz0SQG99cE10GOIhd1p7/mAA==",
+      "requires": {
+        "@sentry/types": "6.3.1",
+>>>>>>> COM-2056 - update babel/core and breaking changes in type/react
         "tslib": "^1.9.3"
       }
     },
@@ -3282,12 +3374,13 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.9.56",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.56.tgz",
-      "integrity": "sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==",
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.4.tgz",
+      "integrity": "sha512-onz2BqScSFMoTRdJUZUDD/7xrusM8hBA2Fktk2qgaTYPCgPvWnDEgkrOs8hhPUf2jfcIXkJ5yK6VfYormJS3Jw==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
+        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
@@ -3298,6 +3391,19 @@
       "dev": true,
       "requires": {
         "@types/react": "^16"
+      },
+      "dependencies": {
+        "@types/react": {
+          "version": "16.14.5",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.5.tgz",
+          "integrity": "sha512-YRRv9DNZhaVTVRh9Wmmit7Y0UFhEVqXqCSw3uazRWMxa2x85hWQZ5BN24i7GXZbaclaLXEcodEeIHsjBA8eAMw==",
+          "dev": true,
+          "requires": {
+            "@types/prop-types": "*",
+            "@types/scheduler": "*",
+            "csstype": "^3.0.2"
+          }
+        }
       }
     },
     "@types/react-native": {
@@ -3308,6 +3414,12 @@
       "requires": {
         "@types/react": "*"
       }
+    },
+    "@types/scheduler": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
+      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==",
+      "dev": true
     },
     "@types/stack-utils": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9288,13 +9288,12 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "react": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-      "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
+        "object-assign": "^4.1.1"
       }
     },
     "react-devtools-core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6506,9 +6506,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inline-style-prefixer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-5.1.2.tgz",
-      "integrity": "sha512-PYUF+94gDfhy+LsQxM0g3d6Hge4l1pAqOSOiZuHWzMvQEGsbRQ/ck2WioLqrY2ZkHyPgVUXxn+hrkF7D6QUGbA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.0.tgz",
+      "integrity": "sha512-XTHvRUS4ZJNzC1GixJRmOlWSS45fSt+DJoyQC9ytj0WxQfcgofQtDtyKKYxHUqEsWCs+LIWftPF1ie7+i012Fg==",
       "requires": {
         "css-in-js-utils": "^2.0.0"
       }
@@ -9719,34 +9719,28 @@
       "integrity": "sha512-35II5oxTaVp3OP8y0eLPOPpQkxG4fRKQ+dL1YSE1we5kCZFOU0l/Rn0T79HbyUu1LPwUZr6lZupPs0ULnRyMuQ=="
     },
     "react-native-web": {
-      "version": "0.13.18",
-      "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.13.18.tgz",
-      "integrity": "sha512-WR/0ECAmwLQ2+2cL2Ur+0/swXFAtcSM0URoADJmG6D4MnY+wGc91JO8LoOTlgY0USBOY+qG/beRrjFa+RAuOiA==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.16.1.tgz",
+      "integrity": "sha512-quSpgBLIg4MiVPLSGX1M/rExdLHjFsXArP4smdD3PvXCTSD5MtdXWsjrbJ96AeYFf792M2BbvsWnj77cXp4gXA==",
       "requires": {
         "array-find-index": "^1.0.2",
-        "create-react-class": "^15.6.2",
+        "create-react-class": "^15.7.0",
         "deep-assign": "^3.0.0",
-        "fbjs": "^1.0.0",
-        "hyphenate-style-name": "^1.0.3",
-        "inline-style-prefixer": "^5.1.0",
+        "fbjs": "^3.0.0",
+        "hyphenate-style-name": "^1.0.4",
+        "inline-style-prefixer": "^6.0.0",
         "normalize-css-color": "^1.0.2",
         "prop-types": "^15.6.0",
         "react-timer-mixin": "^0.13.4"
       },
       "dependencies": {
-        "core-js": {
-          "version": "2.6.12",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-        },
         "fbjs": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
-          "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.0.tgz",
+          "integrity": "sha512-dJd4PiDOFuhe7vk4F80Mba83Vr2QuK86FoxtgPmzBqEJahncp+13YCmfoa53KHCo6OnlXLG7eeMWPfB5CrpVKg==",
           "requires": {
-            "core-js": "^2.4.1",
+            "cross-fetch": "^3.0.4",
             "fbjs-css-vars": "^1.0.0",
-            "isomorphic-fetch": "^2.1.1",
             "loose-envify": "^1.0.0",
             "object-assign": "^4.1.0",
             "promise": "^7.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3385,25 +3385,12 @@
       }
     },
     "@types/react-dom": {
-      "version": "16.9.12",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.12.tgz",
-      "integrity": "sha512-i7NPZZpPte3jtVOoW+eLB7G/jsX5OM6GqQnH+lC0nq0rqwlK0x8WcMEvYDgFWqWhWMlTltTimzdMax6wYfZssA==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.3.tgz",
+      "integrity": "sha512-4NnJbCeWE+8YBzupn/YrJxZ8VnjcJq5iR1laqQ1vkpQgBiA7bwk0Rp24fxsdNinzJY2U+HHS4dJJDPdoMjdJ7w==",
       "dev": true,
       "requires": {
-        "@types/react": "^16"
-      },
-      "dependencies": {
-        "@types/react": {
-          "version": "16.14.5",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.5.tgz",
-          "integrity": "sha512-YRRv9DNZhaVTVRh9Wmmit7Y0UFhEVqXqCSw3uazRWMxa2x85hWQZ5BN24i7GXZbaclaLXEcodEeIHsjBA8eAMw==",
-          "dev": true,
-          "requires": {
-            "@types/prop-types": "*",
-            "@types/scheduler": "*",
-            "csstype": "^3.0.2"
-          }
-        }
+        "@types/react": "*"
       }
     },
     "@types/react-native": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3394,9 +3394,9 @@
       }
     },
     "@types/react-native": {
-      "version": "0.63.52",
-      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.63.52.tgz",
-      "integrity": "sha512-sBXvvtJaIUSXQLDh9NZitx1KHkKUdBLZy34lFKJaIXtpHIh5OEbBXeyUTFBtFwjk/RD0tneAtUqsdhheZRzAzw==",
+      "version": "0.64.4",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.64.4.tgz",
+      "integrity": "sha512-VqnlmadGkD5usREvnuyVpWDS1W8f6cCz6MP5fZdgONsaZ9/Ijfb9Iq9MZ5O3bnW1OyJixDX9HtSp3COsFSLD8Q==",
       "dev": true,
       "requires": {
         "@types/react": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3763,11 +3763,6 @@
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
       "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
     },
-    "array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
-    },
     "array-includes": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
@@ -4617,15 +4612,6 @@
         "parse-json": "^4.0.0"
       }
     },
-    "create-react-class": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.7.0.tgz",
-      "integrity": "sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==",
-      "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
-      }
-    },
     "cross-fetch": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
@@ -4657,15 +4643,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
-    },
-    "css-in-js-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
-      "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
-      "requires": {
-        "hyphenate-style-name": "^1.0.2",
-        "isobject": "^3.0.1"
-      }
     },
     "csstype": {
       "version": "3.0.8",
@@ -6488,11 +6465,6 @@
         "debug": "4"
       }
     },
-    "hyphenate-style-name": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
-      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
-    },
     "iconv-lite": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
@@ -6562,14 +6534,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "inline-style-prefixer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.0.tgz",
-      "integrity": "sha512-XTHvRUS4ZJNzC1GixJRmOlWSS45fSt+DJoyQC9ytj0WxQfcgofQtDtyKKYxHUqEsWCs+LIWftPF1ie7+i012Fg==",
-      "requires": {
-        "css-in-js-utils": "^2.0.0"
-      }
     },
     "inquirer": {
       "version": "3.3.0",
@@ -8431,11 +8395,6 @@
         "minimist": "^1.2.5"
       }
     },
-    "mockdate": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.5.tgz",
-      "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ=="
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -8520,11 +8479,6 @@
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.13.3.tgz",
       "integrity": "sha512-Vv95ug+8Jfug4AxcqNV7TeGEk2antNidj+YBOyP8SS8LTHJmjsE3d9h6L831eJtO8p7jesJ3CDtgkwmLO/wcSw=="
-    },
-    "normalize-css-color": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/normalize-css-color/-/normalize-css-color-1.0.2.tgz",
-      "integrity": "sha1-Apkel8zOxmI/5XOvu/Deah8+n40="
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -9739,33 +9693,6 @@
       "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz",
       "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg=="
     },
-    "react-native-reanimated": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.1.0.tgz",
-      "integrity": "sha512-tlPvvcdf+X7HGQ7g/7npBFhwMznfdk7MHUc9gUB/kp2abSscXNe/kOVKlrNEOO4DS11rNOXc+llFxVFMuNk0zA==",
-      "requires": {
-        "@babel/plugin-transform-object-assign": "^7.10.4",
-        "fbjs": "^3.0.0",
-        "mockdate": "^3.0.2",
-        "string-hash-64": "^1.0.3"
-      },
-      "dependencies": {
-        "fbjs": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.0.tgz",
-          "integrity": "sha512-dJd4PiDOFuhe7vk4F80Mba83Vr2QuK86FoxtgPmzBqEJahncp+13YCmfoa53KHCo6OnlXLG7eeMWPfB5CrpVKg==",
-          "requires": {
-            "cross-fetch": "^3.0.4",
-            "fbjs-css-vars": "^1.0.0",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.18"
-          }
-        }
-      }
-    },
     "react-native-safe-area-context": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-3.2.0.tgz",
@@ -9776,47 +9703,10 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-3.0.0.tgz",
       "integrity": "sha512-35II5oxTaVp3OP8y0eLPOPpQkxG4fRKQ+dL1YSE1we5kCZFOU0l/Rn0T79HbyUu1LPwUZr6lZupPs0ULnRyMuQ=="
     },
-    "react-native-web": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.16.1.tgz",
-      "integrity": "sha512-quSpgBLIg4MiVPLSGX1M/rExdLHjFsXArP4smdD3PvXCTSD5MtdXWsjrbJ96AeYFf792M2BbvsWnj77cXp4gXA==",
-      "requires": {
-        "array-find-index": "^1.0.2",
-        "create-react-class": "^15.7.0",
-        "deep-assign": "^3.0.0",
-        "fbjs": "^3.0.0",
-        "hyphenate-style-name": "^1.0.4",
-        "inline-style-prefixer": "^6.0.0",
-        "normalize-css-color": "^1.0.2",
-        "prop-types": "^15.6.0",
-        "react-timer-mixin": "^0.13.4"
-      },
-      "dependencies": {
-        "fbjs": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.0.tgz",
-          "integrity": "sha512-dJd4PiDOFuhe7vk4F80Mba83Vr2QuK86FoxtgPmzBqEJahncp+13YCmfoa53KHCo6OnlXLG7eeMWPfB5CrpVKg==",
-          "requires": {
-            "cross-fetch": "^3.0.4",
-            "fbjs-css-vars": "^1.0.0",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.18"
-          }
-        }
-      }
-    },
     "react-refresh": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
       "integrity": "sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA=="
-    },
-    "react-timer-mixin": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/react-timer-mixin/-/react-timer-mixin-0.13.4.tgz",
-      "integrity": "sha512-4+ow23tp/Tv7hBM5Az5/Be/eKKF7DIvJ09voz5LyHGQaqqz9WV8YMs31eFvcYQs7d451LSg7kDJV70XYN/Ug/Q=="
     },
     "read-env": {
       "version": "1.3.0",
@@ -10719,11 +10609,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
       "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
-    },
-    "string-hash-64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string-hash-64/-/string-hash-64-1.0.3.tgz",
-      "integrity": "sha512-D5OKWKvDhyVWWn2x5Y9b+37NUllks34q1dCDhk/vYcso9fmhs+Tl3KR/gE4v5UNj2UA35cnX4KdVVGkG1deKqw=="
     },
     "string-width": {
       "version": "4.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2688,35 +2688,6 @@
       }
     },
     "@sentry/browser": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.3.3.tgz",
-      "integrity": "sha512-M3l4xdpU4fTNERnuXZ46ceMa+bAMdUOaSYbmflYt5GSkBuYS/eC8nAaCj//4CMT4JMwT3oUKYI5k6wDIKgyKMQ==",
-      "requires": {
-        "@sentry/core": "6.3.3",
-        "@sentry/types": "6.3.3",
-        "@sentry/utils": "6.3.3",
-=======
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.3.1.tgz",
-      "integrity": "sha512-Ri4tYsyuJIeLQnvQUqbpGzailUYpbjFSYM0+yEM63gPsjiXdg+W8yKHluA6cs6FLWVN3oWfwHW7Kd61echlGuw==",
-      "requires": {
-        "@sentry/core": "6.3.1",
-        "@sentry/types": "6.3.1",
-        "@sentry/utils": "6.3.1",
->>>>>>> COM-2056 - update babel/core and breaking changes in type/react
-=======
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.3.2.tgz",
-      "integrity": "sha512-j0uo20C7Zrv1C8RAfwkZYV5uxDu34Ann+g7HiJ7LEjYBRFqb3as3nAzi7wh+0yCoDqBmxDiELRAObsTtsvxabw==",
-      "requires": {
-        "@sentry/core": "6.3.2",
-        "@sentry/types": "6.3.2",
-        "@sentry/utils": "6.3.2",
->>>>>>> COM-2056 - update typescript
-=======
       "version": "6.3.5",
       "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.3.5.tgz",
       "integrity": "sha512-fjkhPR5gLCGVWhbWjEoN64hnmTvfTLRCgWmYTc9SiGchWFoFEmLqZyF2uJFyt27+qamLQ9fN58nnv4Ly2yyxqg==",
@@ -2724,7 +2695,6 @@
         "@sentry/core": "6.3.5",
         "@sentry/types": "6.3.5",
         "@sentry/utils": "6.3.5",
->>>>>>> COM-2056 expo update
         "tslib": "^1.9.3"
       }
     },
@@ -2742,38 +2712,6 @@
       }
     },
     "@sentry/core": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.3.3.tgz",
-      "integrity": "sha512-wbmXmhWHpbFLmXf9DBUOp9H5Ao+T8Ztn5KXoxDwBnsYXtgVIzQfdpRbtcNtvJJ/UPZ3H3rRHQ8zQTb5Ni99xYQ==",
-      "requires": {
-        "@sentry/hub": "6.3.3",
-        "@sentry/minimal": "6.3.3",
-        "@sentry/types": "6.3.3",
-        "@sentry/utils": "6.3.3",
-=======
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.3.1.tgz",
-      "integrity": "sha512-aVuvVbaehGeN86jZlLDGGkhEtprdOtB6lvYLfGy40Dj1Tkh2mGWE550QsRXAXAqYvQzIYwQR23r6m3o8FujgVg==",
-      "requires": {
-        "@sentry/hub": "6.3.1",
-        "@sentry/minimal": "6.3.1",
-        "@sentry/types": "6.3.1",
-        "@sentry/utils": "6.3.1",
->>>>>>> COM-2056 - update babel/core and breaking changes in type/react
-=======
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.3.2.tgz",
-      "integrity": "sha512-Qag3Tcj6jVNh3wPsuFvIKo3sv3W6TprciTrHYu0vHWB5CLc2Ajq1y05Ac/DwT+tw6/PoJ7l3iTl7rK+lDWP9jg==",
-      "requires": {
-        "@sentry/hub": "6.3.2",
-        "@sentry/minimal": "6.3.2",
-        "@sentry/types": "6.3.2",
-        "@sentry/utils": "6.3.2",
->>>>>>> COM-2056 - update typescript
-=======
       "version": "6.3.5",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.3.5.tgz",
       "integrity": "sha512-VR2ibDy33mryD0mT6d9fGhKjdNzS2FSwwZPe9GvmNOjkyjly/oV91BKVoYJneCqOeq8fyj2lvkJGKuupdJNDqg==",
@@ -2782,119 +2720,37 @@
         "@sentry/minimal": "6.3.5",
         "@sentry/types": "6.3.5",
         "@sentry/utils": "6.3.5",
->>>>>>> COM-2056 expo update
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.3.3.tgz",
-      "integrity": "sha512-vrJHrDKTCAL63dkNNll18Q1c7YjuIYYv5jY56RNUQpm+7sX4v+iw9giOI+iLbPKaGpEyraa17FeF/xO0SqIp9Q==",
-      "requires": {
-        "@sentry/types": "6.3.3",
-        "@sentry/utils": "6.3.3",
-=======
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.3.1.tgz",
-      "integrity": "sha512-2er+OeVlsdVZkhl9kXQAANwgjwoCdM1etK2iFuhzX8xkMaJlAuZLyQInv2U1BbXBlIfWjvzRM8B95hCWvVrR3Q==",
-      "requires": {
-        "@sentry/types": "6.3.1",
-        "@sentry/utils": "6.3.1",
->>>>>>> COM-2056 - update babel/core and breaking changes in type/react
-=======
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.3.2.tgz",
-      "integrity": "sha512-HClMNBj365SXE2WeRq6lO8HJwztkmml7Ep4lZ09opKLzo37DK4iVWfiqQPpFSXVp89XmmrHTixE8Q+mmCqOelQ==",
-      "requires": {
-        "@sentry/types": "6.3.2",
-        "@sentry/utils": "6.3.2",
->>>>>>> COM-2056 - update typescript
-=======
       "version": "6.3.5",
       "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.3.5.tgz",
       "integrity": "sha512-ZYFo7VYKwdPVjuV9BDFiYn+MpANn6eZMz5QDBfZ2dugIvIVbuOyOOLx8PSa3ZXJoVTZZ7s2wD2fi/ZxKjNjZOQ==",
       "requires": {
         "@sentry/types": "6.3.5",
         "@sentry/utils": "6.3.5",
->>>>>>> COM-2056 expo update
         "tslib": "^1.9.3"
       }
     },
     "@sentry/integrations": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.3.3.tgz",
-      "integrity": "sha512-cAqUWfZvSLqTeNl6/9OL5dq3CJkLjVRmbG7ksvpKF1jqSHWiCk5tTmFEL+KI6gv2jqt9HBOfSr6JDGsfTPpX0w==",
-      "requires": {
-        "@sentry/types": "6.3.3",
-        "@sentry/utils": "6.3.3",
-=======
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.3.1.tgz",
-      "integrity": "sha512-fB0+CmU2L2VJ8WyI33t060lxpBNAoh092jzMGEnnfPKTVMxnscjFrISzrWXQZs/OoR6q8Yo/+pZAT5gWA0dDOQ==",
-      "requires": {
-        "@sentry/types": "6.3.1",
-        "@sentry/utils": "6.3.1",
->>>>>>> COM-2056 - update babel/core and breaking changes in type/react
-=======
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.3.2.tgz",
-      "integrity": "sha512-NGdPsnPXOLXgOsRD7bnzUsFhVYocex7DhvnZqBqaTWN4qkZEVX417HhtHhTys4cfWh47hg5ev9Q73j8Av71emw==",
-      "requires": {
-        "@sentry/types": "6.3.2",
-        "@sentry/utils": "6.3.2",
->>>>>>> COM-2056 - update typescript
-=======
       "version": "6.3.5",
       "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.3.5.tgz",
       "integrity": "sha512-0+AN1JPz+JO/wSLW74mrCxdvxepwxe3u4swn8toPFuhNWiI+zpkZYr/Ic4EYDjLARn4Ouyba28uqESPDq8y0fw==",
       "requires": {
         "@sentry/types": "6.3.5",
         "@sentry/utils": "6.3.5",
->>>>>>> COM-2056 expo update
         "localforage": "^1.8.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.3.3.tgz",
-      "integrity": "sha512-MKspEQ5hhTMrbeiNvkRGgm/NX2gM/Mni0vDJjuqQFi2Cd3RwA4ZVO6yRr6XzFPtTGgDsrXg75lQ8rma96Qs8/g==",
-      "requires": {
-        "@sentry/hub": "6.3.3",
-        "@sentry/types": "6.3.3",
-=======
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.3.1.tgz",
-      "integrity": "sha512-0eN9S7HvXsCQEjX/qXHTMgvSb3mwrnZEWS9Qz/Bz5ig9pEGXKgJ1om5NTTHVHhXqd3wFCjdvIo6slufLHoCtSw==",
-      "requires": {
-        "@sentry/hub": "6.3.1",
-        "@sentry/types": "6.3.1",
->>>>>>> COM-2056 - update babel/core and breaking changes in type/react
-=======
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.3.2.tgz",
-      "integrity": "sha512-AZsom90oPEwQTRNzkXgdwu5BN1gNbI+AkBnKA26O8Ysm4JSpGlo5OcYHBPzrkNc8CS2F6sQwG6lRUj1Nl1KBgw==",
-      "requires": {
-        "@sentry/hub": "6.3.2",
-        "@sentry/types": "6.3.2",
->>>>>>> COM-2056 - update typescript
-=======
       "version": "6.3.5",
       "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.3.5.tgz",
       "integrity": "sha512-4RqIGAU0+8iI/1sw0GYPTr4SUA88/i2+JPjFJ+qloh5ANVaNwhFPRChw+Ys9xpre8LV9JZrEsEf8AvQr4fkNbA==",
       "requires": {
         "@sentry/hub": "6.3.5",
         "@sentry/types": "6.3.5",
->>>>>>> COM-2056 expo update
         "tslib": "^1.9.3"
       }
     },
@@ -3105,49 +2961,16 @@
       }
     },
     "@sentry/types": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.3.tgz",
-      "integrity": "sha512-UPHzhwqdjta7LCFfqNvJ5g79lRiXOxtgnIp7zlBkHU6yZs4fPnlBadljyi2gGFguN+C+XAukrbXUAq2mb+Mhdw=="
-    },
-    "@sentry/utils": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.3.3.tgz",
-      "integrity": "sha512-Kz546LeF6Ff/FU53XUVaairMQYFc6sIHBvE5ReZmfDRpaR+qZnfIbWhfoIbSwyBbtF+T8/gcU7mcZpZQmM5jLw==",
-      "requires": {
-        "@sentry/types": "6.3.3",
-=======
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.1.tgz",
-      "integrity": "sha512-BEBn8JX1yaooCAuonbaMci9z0RjwwMbQ3Eny/eyDdd+rjXprZCZaStZnCvSThbNBqAJ8YaUqY2YBMnEwJxarAw=="
-=======
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.2.tgz",
-      "integrity": "sha512-LtVhKQABar7WhXyj/FM9v7bsIqDfDHhQkTA6saHHIIpvfJsCzaoORZD98tqxuV/6+bxT8LvncK6+XZ44spFtrA=="
->>>>>>> COM-2056 - update typescript
-=======
       "version": "6.3.5",
       "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.5.tgz",
       "integrity": "sha512-tY/3pkAmGYJ3F0BtwInsdt/uclNvF8aNG7XHsTPQNzk7BkNVWjCXx0sjxi6CILirl5nwNxYxVeTr2ZYAEZ/dSQ=="
->>>>>>> COM-2056 expo update
     },
     "@sentry/utils": {
       "version": "6.3.5",
       "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.3.5.tgz",
       "integrity": "sha512-kHUcZ37QYlNzz7c9LVdApITXHaNmQK7+sw/If3M/qpff1fd5XoecA8laLfcYuz+Cw5mRhVmdhPcCRM3Xi1IGXg==",
       "requires": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-        "@sentry/types": "6.3.1",
->>>>>>> COM-2056 - update babel/core and breaking changes in type/react
-=======
-        "@sentry/types": "6.3.2",
->>>>>>> COM-2056 - update typescript
-=======
         "@sentry/types": "6.3.5",
->>>>>>> COM-2056 expo update
         "tslib": "^1.9.3"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,45 +11,46 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.13.15",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.15.tgz",
-      "integrity": "sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA=="
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.0.tgz",
+      "integrity": "sha512-vu9V3uMM/1o5Hl5OekMUowo3FqXLJSw+s+66nt0fSWVWTtmosdzn45JHOB3cPtZoe6CTBDzvSw0RdOY85Q37+Q=="
     },
     "@babel/core": {
-      "version": "7.13.16",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.16.tgz",
-      "integrity": "sha512-sXHpixBiWWFti0AV2Zq7avpTasr6sIAu7Y396c608541qAU2ui4a193m0KSQmfPSKFZLnQ3cvlKDOm3XkuXm3Q==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
+      "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
       "requires": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.13.16",
-        "@babel/helper-compilation-targets": "^7.13.16",
-        "@babel/helper-module-transforms": "^7.13.14",
-        "@babel/helpers": "^7.13.16",
-        "@babel/parser": "^7.13.16",
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.15",
-        "@babel/types": "^7.13.16",
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.9.0",
+        "@babel/helper-module-transforms": "^7.9.0",
+        "@babel/helpers": "^7.9.0",
+        "@babel/parser": "^7.9.0",
+        "@babel/template": "^7.8.6",
+        "@babel/traverse": "^7.9.0",
+        "@babel/types": "^7.9.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
+        "gensync": "^1.0.0-beta.1",
         "json5": "^2.1.2",
-        "semver": "^6.3.0",
+        "lodash": "^4.17.13",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
         "source-map": "^0.5.0"
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },
     "@babel/generator": {
-      "version": "7.13.16",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.16.tgz",
-      "integrity": "sha512-grBBR75UnKOcUWMp8WoDxNsWCFl//XCK6HWTrBQKTr5SV9f5g0pNOjdyzi/DTBv12S9GnYPInIXQBTky7OXEMg==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.0.tgz",
+      "integrity": "sha512-C6u00HbmsrNPug6A+CiNl8rEys7TsdcXwg12BHi2ca5rUfAs3+UwZsuDQSXnc+wCElCXMB8gMaJ3YXDdh8fAlg==",
       "requires": {
-        "@babel/types": "^7.13.16",
+        "@babel/types": "^7.14.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
@@ -90,14 +91,15 @@
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.13.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.13.11.tgz",
-      "integrity": "sha512-ays0I7XYq9xbjCSvT+EvysLgfc3tOkwCULHjrnscGT3A9qD4sk3wXnJ3of0MAWsWGjdinFvajHU2smYuqXKMrw==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.0.tgz",
+      "integrity": "sha512-6pXDPguA5zC40Y8oI5mqr+jEUpjMJonKvknvA+vD8CYDz5uuXEwWBK8sRAsE/t3gfb1k15AQb9RhwpscC4nUJQ==",
       "requires": {
+        "@babel/helper-annotate-as-pure": "^7.12.13",
         "@babel/helper-function-name": "^7.12.13",
-        "@babel/helper-member-expression-to-functions": "^7.13.0",
+        "@babel/helper-member-expression-to-functions": "^7.13.12",
         "@babel/helper-optimise-call-expression": "^7.12.13",
-        "@babel/helper-replace-supers": "^7.13.0",
+        "@babel/helper-replace-supers": "^7.13.12",
         "@babel/helper-split-export-declaration": "^7.12.13"
       }
     },
@@ -184,18 +186,18 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.13.14",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
-      "integrity": "sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.0.tgz",
+      "integrity": "sha512-L40t9bxIuGOfpIGA3HNkJhU9qYrf4y5A5LUSw7rGMSn+pcG8dfJ0g6Zval6YJGd2nEjI7oP00fRdnhLKndx6bw==",
       "requires": {
         "@babel/helper-module-imports": "^7.13.12",
         "@babel/helper-replace-supers": "^7.13.12",
         "@babel/helper-simple-access": "^7.13.12",
         "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/helper-validator-identifier": "^7.14.0",
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.13",
-        "@babel/types": "^7.13.14"
+        "@babel/traverse": "^7.14.0",
+        "@babel/types": "^7.14.0"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -257,9 +259,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+      "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A=="
     },
     "@babel/helper-validator-option": {
       "version": "7.12.17",
@@ -278,21 +280,21 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.13.17",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.17.tgz",
-      "integrity": "sha512-Eal4Gce4kGijo1/TGJdqp3WuhllaMLSrW6XcL0ulyUAQOuxHcCafZE8KHg9857gcTehsm/v7RcOx2+jp0Ryjsg==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.0.tgz",
+      "integrity": "sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==",
       "requires": {
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.17",
-        "@babel/types": "^7.13.17"
+        "@babel/traverse": "^7.14.0",
+        "@babel/types": "^7.14.0"
       }
     },
     "@babel/highlight": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
-      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
+      "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/helper-validator-identifier": "^7.14.0",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -315,9 +317,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.13.16",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.16.tgz",
-      "integrity": "sha512-6bAg36mCwuqLO0hbR+z7PHuqWiCeP7Dzg73OpQwsAB1Eb8HnGEz5xYBzCfbu+YjoaJsJs+qheDxVAuqbt3ILEw=="
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.0.tgz",
+      "integrity": "sha512-AHbfoxesfBALg33idaTBVUkLnfXtsgvJREf93p4p0Lwsz4ppfE7g1tpEXVm4vrxUcH4DVhAa9Z1m1zqf9WUC7Q=="
     },
     "@babel/plugin-external-helpers": {
       "version": "7.12.13",
@@ -737,23 +739,23 @@
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.13.0.tgz",
-      "integrity": "sha512-EKy/E2NHhY/6Vw5d1k3rgoobftcNUmp9fGjb9XZwQLtTctsRBOTRO7RHHxfIky1ogMN5BxN7p9uMA3SzPfotMQ==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.14.0.tgz",
+      "integrity": "sha512-CF4c5LX4LQ03LebQxJ5JZes2OYjzBuk1TdiF7cG7d5dK4lAdw9NZmaxq5K/mouUdNeqwz3TNjnW6v01UqUNgpQ==",
       "requires": {
-        "@babel/helper-module-transforms": "^7.13.0",
+        "@babel/helper-module-transforms": "^7.14.0",
         "@babel/helper-plugin-utils": "^7.13.0",
         "babel-plugin-dynamic-import-node": "^2.3.3"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.13.8.tgz",
-      "integrity": "sha512-9QiOx4MEGglfYZ4XOnU79OHr6vIWUakIj9b4mioN8eQIoEh+pf5p/zEB36JpDFWA12nNMiRf7bfoRvl9Rn79Bw==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.14.0.tgz",
+      "integrity": "sha512-EX4QePlsTaRZQmw9BsoPeyh5OCtRGIhwfLquhxGp5e32w+dyL8htOcDwamlitmNFK6xBZYlygjdye9dbd9rUlQ==",
       "requires": {
-        "@babel/helper-module-transforms": "^7.13.0",
+        "@babel/helper-module-transforms": "^7.14.0",
         "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/helper-simple-access": "^7.12.13",
+        "@babel/helper-simple-access": "^7.13.12",
         "babel-plugin-dynamic-import-node": "^2.3.3"
       }
     },
@@ -770,11 +772,11 @@
       }
     },
     "@babel/plugin-transform-modules-umd": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.13.0.tgz",
-      "integrity": "sha512-D/ILzAh6uyvkWjKKyFE/W0FzWwasv6vPTSqPcjxFqn6QpX3u8DjRVliq4F2BamO2Wee/om06Vyy+vPkNrd4wxw==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.14.0.tgz",
+      "integrity": "sha512-nPZdnWtXXeY7I87UZr9VlsWme3Y0cfFFE41Wbxz4bbaexAjNMInXPFUpRRUJ8NoMm0Cw+zxbqjdPmLhcjfazMw==",
       "requires": {
-        "@babel/helper-module-transforms": "^7.13.0",
+        "@babel/helper-module-transforms": "^7.14.0",
         "@babel/helper-plugin-utils": "^7.13.0"
       }
     },
@@ -1082,9 +1084,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.13.17",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.17.tgz",
-      "integrity": "sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
+      "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -1100,26 +1102,26 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.13.17",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.17.tgz",
-      "integrity": "sha512-BMnZn0R+X6ayqm3C3To7o1j7Q020gWdqdyP50KEoVqaCO2c/Im7sYZSmVgvefp8TTMQ+9CtwuBp0Z1CZ8V3Pvg==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.0.tgz",
+      "integrity": "sha512-dZ/a371EE5XNhTHomvtuLTUyx6UEoJmYX+DT5zBCQN3McHemsuIaKKYqsc/fs26BEkHs/lBZy0J571LP5z9kQA==",
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.13.16",
+        "@babel/generator": "^7.14.0",
         "@babel/helper-function-name": "^7.12.13",
         "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.13.16",
-        "@babel/types": "^7.13.17",
+        "@babel/parser": "^7.14.0",
+        "@babel/types": "^7.14.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.13.17",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
-      "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.0.tgz",
+      "integrity": "sha512-O2LVLdcnWplaGxiPBz12d0HcdN8QdxdsWYhz5LSeuukV/5mn2xUUc3gBeU4QBYPJ18g/UToe8F532XJ608prmg==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.12.11",
+        "@babel/helper-validator-identifier": "^7.14.0",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -1215,38 +1217,6 @@
         "resolve-from": "^5.0.0",
         "semver": "7.3.2",
         "slugify": "^1.3.4"
-      },
-      "dependencies": {
-        "@babel/core": {
-          "version": "7.9.0",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
-          "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
-          "requires": {
-            "@babel/code-frame": "^7.8.3",
-            "@babel/generator": "^7.9.0",
-            "@babel/helper-module-transforms": "^7.9.0",
-            "@babel/helpers": "^7.9.0",
-            "@babel/parser": "^7.9.0",
-            "@babel/template": "^7.8.6",
-            "@babel/traverse": "^7.9.0",
-            "@babel/types": "^7.9.0",
-            "convert-source-map": "^1.7.0",
-            "debug": "^4.1.0",
-            "gensync": "^1.0.0-beta.1",
-            "json5": "^2.1.2",
-            "lodash": "^4.17.13",
-            "resolve": "^1.3.2",
-            "semver": "^5.4.1",
-            "source-map": "^0.5.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-            }
-          }
-        }
       }
     },
     "@expo/config-plugins": {
@@ -2720,6 +2690,7 @@
     "@sentry/browser": {
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
       "version": "6.3.3",
       "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.3.3.tgz",
       "integrity": "sha512-M3l4xdpU4fTNERnuXZ46ceMa+bAMdUOaSYbmflYt5GSkBuYS/eC8nAaCj//4CMT4JMwT3oUKYI5k6wDIKgyKMQ==",
@@ -2745,6 +2716,15 @@
         "@sentry/types": "6.3.2",
         "@sentry/utils": "6.3.2",
 >>>>>>> COM-2056 - update typescript
+=======
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.3.5.tgz",
+      "integrity": "sha512-fjkhPR5gLCGVWhbWjEoN64hnmTvfTLRCgWmYTc9SiGchWFoFEmLqZyF2uJFyt27+qamLQ9fN58nnv4Ly2yyxqg==",
+      "requires": {
+        "@sentry/core": "6.3.5",
+        "@sentry/types": "6.3.5",
+        "@sentry/utils": "6.3.5",
+>>>>>>> COM-2056 expo update
         "tslib": "^1.9.3"
       }
     },
@@ -2762,6 +2742,7 @@
       }
     },
     "@sentry/core": {
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
       "version": "6.3.3",
@@ -2792,10 +2773,21 @@
         "@sentry/types": "6.3.2",
         "@sentry/utils": "6.3.2",
 >>>>>>> COM-2056 - update typescript
+=======
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.3.5.tgz",
+      "integrity": "sha512-VR2ibDy33mryD0mT6d9fGhKjdNzS2FSwwZPe9GvmNOjkyjly/oV91BKVoYJneCqOeq8fyj2lvkJGKuupdJNDqg==",
+      "requires": {
+        "@sentry/hub": "6.3.5",
+        "@sentry/minimal": "6.3.5",
+        "@sentry/types": "6.3.5",
+        "@sentry/utils": "6.3.5",
+>>>>>>> COM-2056 expo update
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
       "version": "6.3.3",
@@ -2820,10 +2812,19 @@
         "@sentry/types": "6.3.2",
         "@sentry/utils": "6.3.2",
 >>>>>>> COM-2056 - update typescript
+=======
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.3.5.tgz",
+      "integrity": "sha512-ZYFo7VYKwdPVjuV9BDFiYn+MpANn6eZMz5QDBfZ2dugIvIVbuOyOOLx8PSa3ZXJoVTZZ7s2wD2fi/ZxKjNjZOQ==",
+      "requires": {
+        "@sentry/types": "6.3.5",
+        "@sentry/utils": "6.3.5",
+>>>>>>> COM-2056 expo update
         "tslib": "^1.9.3"
       }
     },
     "@sentry/integrations": {
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
       "version": "6.3.3",
@@ -2848,11 +2849,20 @@
         "@sentry/types": "6.3.2",
         "@sentry/utils": "6.3.2",
 >>>>>>> COM-2056 - update typescript
+=======
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.3.5.tgz",
+      "integrity": "sha512-0+AN1JPz+JO/wSLW74mrCxdvxepwxe3u4swn8toPFuhNWiI+zpkZYr/Ic4EYDjLARn4Ouyba28uqESPDq8y0fw==",
+      "requires": {
+        "@sentry/types": "6.3.5",
+        "@sentry/utils": "6.3.5",
+>>>>>>> COM-2056 expo update
         "localforage": "^1.8.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
       "version": "6.3.3",
@@ -2877,6 +2887,14 @@
         "@sentry/hub": "6.3.2",
         "@sentry/types": "6.3.2",
 >>>>>>> COM-2056 - update typescript
+=======
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.3.5.tgz",
+      "integrity": "sha512-4RqIGAU0+8iI/1sw0GYPTr4SUA88/i2+JPjFJ+qloh5ANVaNwhFPRChw+Ys9xpre8LV9JZrEsEf8AvQr4fkNbA==",
+      "requires": {
+        "@sentry/hub": "6.3.5",
+        "@sentry/types": "6.3.5",
+>>>>>>> COM-2056 expo update
         "tslib": "^1.9.3"
       }
     },
@@ -3089,6 +3107,7 @@
     "@sentry/types": {
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
       "version": "6.3.3",
       "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.3.tgz",
       "integrity": "sha512-UPHzhwqdjta7LCFfqNvJ5g79lRiXOxtgnIp7zlBkHU6yZs4fPnlBadljyi2gGFguN+C+XAukrbXUAq2mb+Mhdw=="
@@ -3108,18 +3127,27 @@
       "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.2.tgz",
       "integrity": "sha512-LtVhKQABar7WhXyj/FM9v7bsIqDfDHhQkTA6saHHIIpvfJsCzaoORZD98tqxuV/6+bxT8LvncK6+XZ44spFtrA=="
 >>>>>>> COM-2056 - update typescript
+=======
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.5.tgz",
+      "integrity": "sha512-tY/3pkAmGYJ3F0BtwInsdt/uclNvF8aNG7XHsTPQNzk7BkNVWjCXx0sjxi6CILirl5nwNxYxVeTr2ZYAEZ/dSQ=="
+>>>>>>> COM-2056 expo update
     },
     "@sentry/utils": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.3.2.tgz",
-      "integrity": "sha512-R2A5tdcGhkqrEndw5FAwz64Ndd0S529ps+OQggxjKEnhSPTs7vLBhXPE1D8nIInp/tNP2zaXlGJ1xOAqWN/gOg==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.3.5.tgz",
+      "integrity": "sha512-kHUcZ37QYlNzz7c9LVdApITXHaNmQK7+sw/If3M/qpff1fd5XoecA8laLfcYuz+Cw5mRhVmdhPcCRM3Xi1IGXg==",
       "requires": {
+<<<<<<< HEAD
 <<<<<<< HEAD
         "@sentry/types": "6.3.1",
 >>>>>>> COM-2056 - update babel/core and breaking changes in type/react
 =======
         "@sentry/types": "6.3.2",
 >>>>>>> COM-2056 - update typescript
+=======
+        "@sentry/types": "6.3.5",
+>>>>>>> COM-2056 expo update
         "tslib": "^1.9.3"
       }
     },
@@ -3432,39 +3460,32 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.4",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.4.tgz",
-      "integrity": "sha512-onz2BqScSFMoTRdJUZUDD/7xrusM8hBA2Fktk2qgaTYPCgPvWnDEgkrOs8hhPUf2jfcIXkJ5yK6VfYormJS3Jw==",
+      "version": "16.9.56",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.56.tgz",
+      "integrity": "sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
     "@types/react-dom": {
-      "version": "17.0.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.3.tgz",
-      "integrity": "sha512-4NnJbCeWE+8YBzupn/YrJxZ8VnjcJq5iR1laqQ1vkpQgBiA7bwk0Rp24fxsdNinzJY2U+HHS4dJJDPdoMjdJ7w==",
+      "version": "16.9.12",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.12.tgz",
+      "integrity": "sha512-i7NPZZpPte3jtVOoW+eLB7G/jsX5OM6GqQnH+lC0nq0rqwlK0x8WcMEvYDgFWqWhWMlTltTimzdMax6wYfZssA==",
       "dev": true,
       "requires": {
-        "@types/react": "*"
+        "@types/react": "^16"
       }
     },
     "@types/react-native": {
-      "version": "0.64.4",
-      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.64.4.tgz",
-      "integrity": "sha512-VqnlmadGkD5usREvnuyVpWDS1W8f6cCz6MP5fZdgONsaZ9/Ijfb9Iq9MZ5O3bnW1OyJixDX9HtSp3COsFSLD8Q==",
+      "version": "0.63.52",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.63.52.tgz",
+      "integrity": "sha512-sBXvvtJaIUSXQLDh9NZitx1KHkKUdBLZy34lFKJaIXtpHIh5OEbBXeyUTFBtFwjk/RD0tneAtUqsdhheZRzAzw==",
       "dev": true,
       "requires": {
         "@types/react": "*"
       }
-    },
-    "@types/scheduler": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
-      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==",
-      "dev": true
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -4121,13 +4142,13 @@
       }
     },
     "browserslist": {
-      "version": "4.16.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.5.tgz",
-      "integrity": "sha512-C2HAjrM1AI/djrpAUU/tr4pml1DqLIzJKSLDBXBrNErl9ZCCTXdhwxdJjYc16953+mBWf7Lw+uUJgpgb8cN71A==",
+      "version": "4.16.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30001214",
+        "caniuse-lite": "^1.0.30001219",
         "colorette": "^1.2.2",
-        "electron-to-chromium": "^1.3.719",
+        "electron-to-chromium": "^1.3.723",
         "escalade": "^3.1.1",
         "node-releases": "^1.1.71"
       }
@@ -4576,16 +4597,16 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.11.0.tgz",
-      "integrity": "sha512-bd79DPpx+1Ilh9+30aT5O1sgpQd4Ttg8oqkqi51ZzhedMM1omD2e6IOF48Z/DzDCZ2svp49tN/3vneTK6ZBkXw=="
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.11.1.tgz",
+      "integrity": "sha512-k93Isqg7e4txZWMGNYwevZL9MiogLk8pd1PtwrmFmi8IBq4GXqUaVW/a33Llt6amSI36uSjd0GWwc9pTT9ALlQ=="
     },
     "core-js-compat": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.11.0.tgz",
-      "integrity": "sha512-3wsN9YZJohOSDCjVB0GequOyHax8zFiogSX3XWLE28M1Ew7dTU57tgHjIylSBKSIouwmLBp3g61sKMz/q3xEGA==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.11.1.tgz",
+      "integrity": "sha512-aZ0e4tmlG/aOBHj92/TuOuZwp6jFvn1WNabU5VOVixzhu5t5Ao+JZkQOPlgNXu6ynwLrwJxklT4Gw1G1VGEh+g==",
       "requires": {
-        "browserslist": "^4.16.4",
+        "browserslist": "^4.16.5",
         "semver": "7.0.0"
       },
       "dependencies": {
@@ -9209,9 +9230,9 @@
       }
     },
     "protobufjs": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.2.tgz",
-      "integrity": "sha512-27yj+04uF6ya9l+qfpH187aqEzfCF4+Uit0I9ZBQVqK09hk/SQzKa2MUqUpXaVa7LOFRg1TSSr3lVxGOk6c0SQ==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.1.tgz",
+      "integrity": "sha512-7KCLPvNGF/oDv/OXz+Zn2ViJx8x9WUKs5HrxZ5Gz0F2LD8jSTcsA1z9tBtOlPVVnJELOaFL+zj+oLc/WWSqlzw==",
       "dev": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -9225,16 +9246,8 @@
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
         "@types/long": "^4.0.1",
-        "@types/node": "^13.7.0",
+        "@types/node": ">=13.7.0",
         "long": "^4.0.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "13.13.51",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.51.tgz",
-          "integrity": "sha512-66/xg5I5Te4oGi5Jws11PtNmKkZbOPZWyBZZ/l5AOrWj1Dyw+6Ge/JhYTq/2/Yvdqyhrue8RL+DGI298OJ0xcg==",
-          "dev": true
-        }
       }
     },
     "proxy-from-env": {
@@ -9300,9 +9313,9 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
+      "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -9310,9 +9323,9 @@
       }
     },
     "react-devtools-core": {
-      "version": "4.12.4",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.12.4.tgz",
-      "integrity": "sha512-hVCT7wRtA5xWclgLb3oA51RNBAlbuTauEYkqFX+qRAkPLVJoX8qdJnO7r+47SSUckD5vkBm3kaAhg6597m7gDA==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.13.0.tgz",
+      "integrity": "sha512-KR+0pLw8wTjOVr+9AECe5ctmycaAjbmxN3bbdB0vmlwm0JkxNnKMxDzanf+4V8IuPBQWgm8qdWpbSOqhu1l14g==",
       "requires": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
@@ -9326,9 +9339,9 @@
       }
     },
     "react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+      "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -11009,9 +11022,9 @@
       }
     },
     "typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.7.tgz",
+      "integrity": "sha512-yi7M4y74SWvYbnazbn8/bmJmX4Zlej39ZOqwG/8dut/MYoSQ119GY9ZFbbGsD4PFZYWxqik/XsP3vk3+W5H3og==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9288,12 +9288,13 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
+      "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
       }
     },
     "react-devtools-core": {

--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
     "expo-font": "~9.1.0",
     "expo-status-bar": "~1.0.4",
     "react": "^16.13.1",
-    "react-dom": "16.13.1",
+    "react-dom": "^16.13.1",
     "react-native": "https://github.com/expo/react-native/archive/sdk-41.0.0.tar.gz",
     "react-native-gesture-handler": "~1.10.2",
     "react-native-reanimated": "~2.1.0",
     "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "~3.0.0",
-    "react-native-web": "~0.13.12",
+    "react-native-web": "^0.16.1",
     "sentry-expo": "^3.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "expo-firebase-analytics": "~4.0.2",
     "expo-font": "~9.1.0",
     "expo-status-bar": "~1.0.4",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
     "react-native": "https://github.com/expo/react-native/archive/sdk-41.0.0.tar.gz",
     "react-native-gesture-handler": "~1.10.2",
     "react-native-safe-area-context": "3.2.0",
@@ -30,10 +30,10 @@
     "sentry-expo": "^3.1.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.13.16",
-    "@types/react": "^17.0.4",
-    "@types/react-dom": "^17.0.3",
-    "@types/react-native": "^0.64.4",
+    "@babel/core": "~7.9.0",
+    "@types/react": "~16.9.35",
+    "@types/react-dom": "~16.9.8",
+    "@types/react-native": "~0.63.2",
     "@typescript-eslint/eslint-plugin": "^4.20.0",
     "@typescript-eslint/parser": "^4.20.0",
     "eslint": "^7.23.0",
@@ -42,7 +42,7 @@
     "eslint-plugin-react": "^7.23.1",
     "eslint-plugin-react-hooks": "^4.2.0",
     "firebase": "8.2.3",
-    "typescript": "^4.2.4"
+    "typescript": "~4.0.0"
   },
   "private": true
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "expo-firebase-analytics": "~4.0.2",
     "expo-font": "~9.1.0",
     "expo-status-bar": "~1.0.4",
-    "react": "16.13.1",
+    "react": "^17.0.2",
     "react-dom": "16.13.1",
     "react-native": "https://github.com/expo/react-native/archive/sdk-41.0.0.tar.gz",
     "react-native-gesture-handler": "~1.10.2",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "sentry-expo": "^3.1.0"
   },
   "devDependencies": {
-    "@babel/core": "~7.9.0",
-    "@types/react": "~16.9.35",
+    "@babel/core": "^7.13.16",
+    "@types/react": "^17.0.4",
     "@types/react-dom": "~16.9.8",
     "@types/react-native": "~0.63.2",
     "@typescript-eslint/eslint-plugin": "^4.20.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "expo-firebase-analytics": "~4.0.2",
     "expo-font": "~9.1.0",
     "expo-status-bar": "~1.0.4",
-    "react": "^17.0.2",
+    "react": "^16.13.1",
     "react-dom": "16.13.1",
     "react-native": "https://github.com/expo/react-native/archive/sdk-41.0.0.tar.gz",
     "react-native-gesture-handler": "~1.10.2",

--- a/package.json
+++ b/package.json
@@ -25,10 +25,8 @@
     "react-dom": "^16.13.1",
     "react-native": "https://github.com/expo/react-native/archive/sdk-41.0.0.tar.gz",
     "react-native-gesture-handler": "~1.10.2",
-    "react-native-reanimated": "~2.1.0",
     "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "~3.0.0",
-    "react-native-web": "^0.16.1",
     "sentry-expo": "^3.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@babel/core": "^7.13.16",
     "@types/react": "^17.0.4",
-    "@types/react-dom": "~16.9.8",
+    "@types/react-dom": "^17.0.3",
     "@types/react-native": "~0.63.2",
     "@typescript-eslint/eslint-plugin": "^4.20.0",
     "@typescript-eslint/parser": "^4.20.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-plugin-react": "^7.23.1",
     "eslint-plugin-react-hooks": "^4.2.0",
     "firebase": "8.2.3",
-    "typescript": "~4.0.0"
+    "typescript": "^4.2.4"
   },
   "private": true
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@babel/core": "^7.13.16",
     "@types/react": "^17.0.4",
     "@types/react-dom": "^17.0.3",
-    "@types/react-native": "~0.63.2",
+    "@types/react-native": "^0.64.4",
     "@typescript-eslint/eslint-plugin": "^4.20.0",
     "@typescript-eslint/parser": "^4.20.0",
     "eslint": "^7.23.0",


### PR DESCRIPTION
- [x]  j'ai testé sur iOS

Tous les packages étaient bien à jour.

J'ai supprimé deux d'entre eux: `react-native-reanimated` et `react-native-web`. On ne se sert pas de ces packages, ils ont été installés par défaut par expo