### PR TITLE
add android permissions

### DIFF
--- a/app.json
+++ b/app.json
@@ -29,6 +29,7 @@
     "android": {
       "package": "com.compani.erp",
       "versionCode": 1,
+      "permissions": [],
       "adaptiveIcon": { "foregroundImage": "./assets/images/android_icon.png" },
       "googleServicesFile": "./google-services.json"
     },

--- a/app.json
+++ b/app.json
@@ -28,7 +28,7 @@
     },
     "android": {
       "package": "com.compani.erp",
-      "versionCode": 1,
+      "versionCode": 2,
       "permissions": [],
       "adaptiveIcon": { "foregroundImage": "./assets/images/android_icon.png" },
       "googleServicesFile": "./google-services.json"


### PR DESCRIPTION
- [ ] J'ai testé sur iphone -np
- [x] J'ai testé sur android

- [x] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui parce que changement que dans app.json
  - Non parce que

- [x] Je n'envoie pas de nouveau paramètre dans une route
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite:
- [ ] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas -np
- [ ] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas. -np
- [x] Je n'ai pas changé de constante

- J'ai ajouté une variable d'environnement : -np
  - [ ] Je l'ai ajouté dans env.dev et env.prod aussi

- Cas d'usage : https://docs.expo.io/versions/v41.0.0/config/app/#permissions le changement permet de ne demander qu'un minimum de permission a l'utilisateur sur android
