### PR TITLE
Com 2074

### DIFF
--- a/src/components/TimeStampingCell/index.tsx
+++ b/src/components/TimeStampingCell/index.tsx
@@ -27,9 +27,9 @@ const TimeStampingCell = ({ event }: TimeStampingProps) => {
     }
   }, [setCivility, setLastName, setEndDate, setStartDate, event]);
 
-  const goToManualTimeStamping = () => navigation.navigate(
+  const goToManualTimeStamping = (eventStart: boolean) => navigation.navigate(
     'ManualTimeStamping',
-    { event: { _id: event._id, customer: { identity: event.customer.identity } } }
+    { event: { _id: event._id, customer: { identity: event.customer.identity } }, eventStart }
   );
 
   return (
@@ -42,7 +42,7 @@ const TimeStampingCell = ({ event }: TimeStampingProps) => {
           {!!startDate && <Text style={styles.scheduledTime}>{formatTime(startDate)}</Text>}
         </View>
         <View>
-          <NiPrimaryButton title='Commencer' onPress={goToManualTimeStamping}/>
+          <NiPrimaryButton title='Commencer' onPress={() => goToManualTimeStamping(true)} style={styles.button} />
         </View>
       </View>
       <View style={styles.sectionDelimiter} />
@@ -50,6 +50,9 @@ const TimeStampingCell = ({ event }: TimeStampingProps) => {
         <View>
           <Text style={styles.timeTitle}>Fin</Text>
           {!!endDate && <Text style={styles.scheduledTime}>{formatTime(endDate)}</Text>}
+        </View>
+        <View>
+          <NiPrimaryButton title='Terminer' onPress={() => goToManualTimeStamping(false)} style={styles.button} />
         </View>
       </View>
     </View>

--- a/src/components/TimeStampingCell/styles.ts
+++ b/src/components/TimeStampingCell/styles.ts
@@ -1,7 +1,7 @@
 import { StyleSheet } from 'react-native';
 import { GREY, WHITE } from '../../styles/colors';
 import { FIRA_SANS_BOLD, FIRA_SANS_REGULAR, NUNITO_REGULAR } from '../../styles/fonts';
-import { BORDER_RADIUS, BORDER_WIDTH, MARGIN, PADDING } from '../../styles/metrics';
+import { BORDER_RADIUS, BORDER_WIDTH, MARGIN, PADDING, BUTTON_INTERVENTION_WIDTH } from '../../styles/metrics';
 
 export default StyleSheet.create({
   sectionDelimiter: {
@@ -35,5 +35,8 @@ export default StyleSheet.create({
   scheduledTime: {
     ...NUNITO_REGULAR.XXL,
     color: GREY[900],
+  },
+  button: {
+    width: BUTTON_INTERVENTION_WIDTH,
   },
 });

--- a/src/components/form/PrimaryButton/styles.tsx
+++ b/src/components/form/PrimaryButton/styles.tsx
@@ -8,7 +8,7 @@ export default StyleSheet.create({
     ...commonStyle.button,
     backgroundColor: PINK[500],
     color: WHITE,
-    paddingHorizontal: PADDING.XL,
+    paddingHorizontal: PADDING.LG,
   },
   textButton: {
     ...commonStyle.textButton,

--- a/src/screens/timeStamping/ManualTimeStamping/index.tsx
+++ b/src/screens/timeStamping/ManualTimeStamping/index.tsx
@@ -11,7 +11,7 @@ import { GREY } from '../../../styles/colors';
 import styles from './styles';
 
 interface ManualTimeStampingProps {
-  route: { params: { event: { _id: string, customer: { identity: any } } } },
+  route: { params: { event: { _id: string, customer: { identity: any } }, eventStart: boolean, } },
 }
 
 const optionList = [
@@ -22,12 +22,13 @@ const optionList = [
 
 const ManualTimeStamping = ({ route }: ManualTimeStampingProps) => {
   const [currentTime] = useState<Date>(new Date());
-  const navigation = useNavigation();
-
   const [civility, setCivility] = useState<string>(route.params.event?.customer?.identity?.title || '');
   const [lastname, setLastname] = useState<string>(
     route.params.event?.customer?.identity?.lastname.toUpperCase() || ''
   );
+  const navigation = useNavigation();
+
+  const title = route.params.eventStart ? 'Début de l\'intervention' : 'Fin de l\'intervention';
 
   useEffect(() => {
     setCivility(route.params.event?.customer?.identity?.title || '');
@@ -40,7 +41,7 @@ const ManualTimeStamping = ({ route }: ManualTimeStampingProps) => {
     <View style={styles.screen}>
       <FeatherButton name='x-circle' onPress={goBack} size={ICON.MD} color={GREY[600]} />
       <View style={styles.container}>
-        <Text style={styles.title}>Début de l&apos;intervention</Text>
+        <Text style={styles.title}>{title}</Text>
         <View style={styles.cell}>
           <View style={styles.customerInfo}>
             <Text style={styles.subtitle}>Bénéficiaire</Text>

--- a/src/screens/timeStamping/ManualTimeStamping/index.tsx
+++ b/src/screens/timeStamping/ManualTimeStamping/index.tsx
@@ -27,13 +27,13 @@ const ManualTimeStamping = ({ route }: ManualTimeStampingProps) => {
     route.params.event?.customer?.identity?.lastname.toUpperCase() || ''
   );
   const navigation = useNavigation();
-
-  const title = route.params.eventStart ? 'Début de l\'intervention' : 'Fin de l\'intervention';
+  const [title, setTitle] = useState<string>('');
 
   useEffect(() => {
     setCivility(route.params.event?.customer?.identity?.title || '');
     setLastname(route.params.event?.customer?.identity?.lastname.toUpperCase() || '');
-  }, [route.params.event]);
+    setTitle(route.params.eventStart ? 'Début de l\'intervention' : 'Fin de l\'intervention');
+  }, [route.params]);
 
   const goBack = () => navigation.navigate('Home');
 

--- a/src/styles/metrics.ts
+++ b/src/styles/metrics.ts
@@ -46,6 +46,7 @@ export const BUTTON_HEIGHT = 48;
 export const INPUT_HEIGHT = 48;
 export const BORDER_WIDTH = 1;
 export const TAB_BAR_HEIGHT = 72;
+export const BUTTON_INTERVENTION_WIDTH = 135;
 
 export const SCREEN_HEIGHT = width < height ? height : width;
 export const SMALL_SCREEN_MAX_HEIGHT = 568;

--- a/src/styles/metrics.ts
+++ b/src/styles/metrics.ts
@@ -46,7 +46,7 @@ export const BUTTON_HEIGHT = 48;
 export const INPUT_HEIGHT = 48;
 export const BORDER_WIDTH = 1;
 export const TAB_BAR_HEIGHT = 72;
-export const BUTTON_INTERVENTION_WIDTH = 135;
+export const BUTTON_INTERVENTION_WIDTH = 128;
 
 export const SCREEN_HEIGHT = width < height ? height : width;
 export const SMALL_SCREEN_MAX_HEIGHT = 568;


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- [x] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui 
  - Non parce que

- [ ] Je n'envoie pas de nouveau paramètre dans une route -np
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite:
- [ ] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas -np
- [ ] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas. -np
- [ ] Je n'ai pas changé de constante -np

- J'ai ajouté une variable d'environnement : -np
  - [ ] Je l'ai ajouté dans env.dev et env.prod aussi

- Cas d'usage : Sur la page horodatage, l'auxiliaire accéde au bouton `Terminer`, un clique sur ce bouton renvoie vers la page d'horodatée manuel avec le titre `fin de l'intervention`.

En ajoutant le bouton `terminer`, je me suis aperçue que la largeur des deux boutons `Commencer` et `Terminer` n'était pas la même. 

Apres discussion avec Romain, il préfère que l'on modifie le padding sur tous les boutons et que l'on définisse une largeur de bouton de 128 sur la page `ManualTimeStamping`

J'ai vérifié que ce changement n'apporte pas de changements indesirés sur les boutons déjà existants: 
- bouton dans la modale de mise a jour
- bouton valider dans passwordForm 
- bouton se connecter sur la page Authentification
- 2 boutons valider dans ForgotPassword ( pour valider l'email et pour valider le code reçu par mail ou sms)
- bouton valider et horodateur dans manualTimeStamping