### PR TITLE
COM-2025 - add store redirections

### DIFF
--- a/src/components/modals/UpdateAppModal/index.tsx
+++ b/src/components/modals/UpdateAppModal/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text } from 'react-native';
+import { Text, Linking, Platform } from 'react-native';
 import NiModal from '../Modal';
 import NiPrimaryButton from '../../form/PrimaryButton';
 import styles from './styles';
@@ -9,16 +9,22 @@ interface UpdateAppModalProps {
   visible: boolean,
 }
 
-const UpdateAppModal = ({ visible }: UpdateAppModalProps) => (
-  <NiModal visible={visible}>
-    <>
-      <Text style={modalStyles.title}> Nouvelle version de l&apos;app disponible !</Text>
-      <Text style={[modalStyles.body, styles.body]}>
-        Merci de mettre à jour votre application pour pouvoir continuer à l&apos;utiliser :)
-      </Text>
-      <NiPrimaryButton title="Mettre à jour" onPress={() => {}}/>
-    </>
-  </NiModal>
-);
+const UpdateAppModal = ({ visible }: UpdateAppModalProps) => {
+  const appUrl = Platform.OS === 'ios'
+    ? 'https://apps.apple.com/app/id/1564254334'
+    : 'market://details?id=com.compani.erp';
+
+  return (
+    <NiModal visible={visible}>
+      <>
+        <Text style={modalStyles.title}> Nouvelle version de l&apos;app disponible !</Text>
+        <Text style={[modalStyles.body, styles.body]}>
+          Merci de mettre à jour votre application pour pouvoir continuer à l&apos;utiliser :)
+        </Text>
+        <NiPrimaryButton title="Mettre à jour" onPress={() => { Linking.openURL(appUrl); }}/>
+      </>
+    </NiModal>
+  );
+};
 
 export default UpdateAppModal;


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- [x] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui parce que je ne fais pas de changement au niveau des routes
  - Non parce que

- [x] Je n'envoie pas de nouveau paramètre dans une route
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite:
- [ ] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas
- [ ] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas.
- [x] Je n'ai pas changé de constante

- J'ai ajouté une variable d'environnement :
  - [ ] Je l'ai ajouté dans env.dev et env.prod aussi

- Cas d'usage : Tant que l'app n'est pas vraiment sur les stores (en prod), la page n'existe pas donc je en sais pas trop comment tester...
