### PR TITLE
COM-2074 can timestamp end of intervention

### DIFF
--- a/src/api/Events.ts
+++ b/src/api/Events.ts
@@ -2,7 +2,7 @@ import axiosLogged from './axios/logged';
 import Environment from '../../environment';
 import { EventTypeEnum } from '../types/EventType';
 
-export interface timeStampEventPayloadType { action: string, reason: string, startDate?: Date, endDate?: Date }
+export type timeStampEventPayloadType = { action: string, reason: string, startDate?: Date, endDate?: Date };
 
 export default {
   events: async (params: { auxiliary: string, startDate: Date, endDate: Date, type: EventTypeEnum }) => {

--- a/src/api/Events.ts
+++ b/src/api/Events.ts
@@ -2,13 +2,15 @@ import axiosLogged from './axios/logged';
 import Environment from '../../environment';
 import { EventTypeEnum } from '../types/EventType';
 
+export interface timeStampEventPayloadType { action: string, reason: string, startDate?: Date, endDate?: Date }
+
 export default {
   events: async (params: { auxiliary: string, startDate: Date, endDate: Date, type: EventTypeEnum }) => {
     const { baseURL } = Environment.getEnvVars();
     const events = await axiosLogged.get(`${baseURL}/events`, { params });
     return events.data.data.events;
   },
-  timeStampEvent: async (id: string, data: object) => {
+  timeStampEvent: async (id: string, data: timeStampEventPayloadType) => {
     const { baseURL } = Environment.getEnvVars();
     await axiosLogged.put(`${baseURL}/events/${id}/timestamping`, data);
   },

--- a/src/screens/timeStamping/ManualTimeStamping/index.tsx
+++ b/src/screens/timeStamping/ManualTimeStamping/index.tsx
@@ -57,10 +57,12 @@ const ManualTimeStamping = ({ route }: ManualTimeStampingProps) => {
         return;
       }
 
-      await Events.timeStampEvent(
-        route.params?.event?._id,
-        { action: MANUAL_TIME_STAMPING, reason, startDate: new Date() }
-      );
+      interface payloadType { action: string, reason: string, startDate?: Date, endDate?: Date }
+      const payload: payloadType = { action: MANUAL_TIME_STAMPING, reason };
+      if (route.params.eventStart) payload.startDate = new Date();
+      else payload.endDate = new Date();
+
+      await Events.timeStampEvent(route.params?.event?._id, payload);
       navigation.navigate('Home');
     } catch (e) {
       console.error(e);

--- a/src/screens/timeStamping/ManualTimeStamping/index.tsx
+++ b/src/screens/timeStamping/ManualTimeStamping/index.tsx
@@ -10,7 +10,7 @@ import NiErrorMessage from '../../../components/ErrorMessage';
 import { ICON } from '../../../styles/metrics';
 import { GREY } from '../../../styles/colors';
 import styles from './styles';
-import Events from '../../../api/Events';
+import Events, { timeStampEventPayloadType } from '../../../api/Events';
 
 interface ManualTimeStampingProps {
   route: { params: { event: { _id: string, customer: { identity: any } }, eventStart: boolean, } },
@@ -57,8 +57,7 @@ const ManualTimeStamping = ({ route }: ManualTimeStampingProps) => {
         return;
       }
 
-      interface payloadType { action: string, reason: string, startDate?: Date, endDate?: Date }
-      const payload: payloadType = { action: MANUAL_TIME_STAMPING, reason };
+      const payload: timeStampEventPayloadType = { action: MANUAL_TIME_STAMPING, reason };
       if (route.params.eventStart) payload.startDate = new Date();
       else payload.endDate = new Date();
 


### PR DESCRIPTION
- [ ] J'ai testé sur iphone
- [x] J'ai testé sur android

- [] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api) -np
  - Oui parce que
  - Non parce que

- [ ] Je n'envoie pas de nouveau paramètre dans une route
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite: app pas en prod
- [ ] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas
- [ ] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas.
- [ ] Je n'ai pas changé de constante

- J'ai ajouté une variable d'environnement : -np
  - [ ] Je l'ai ajouté dans env.dev et env.prod aussi

- Cas d'usage : Je peux horodater la fin d'une intervention
