### PR TITLE
Com 2108 npm update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,9 +46,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.2.tgz",
-      "integrity": "sha512-OnADYbKrffDVai5qcpkMxQ7caomHOoEwjkouqnN2QhydAjowFAZcsdecFIRUBdb+ZcruwYE4ythYmF1UBZU5xQ==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
+      "integrity": "sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==",
       "requires": {
         "@babel/types": "^7.14.2",
         "jsesc": "^2.5.1",
@@ -91,31 +91,31 @@
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.2.tgz",
-      "integrity": "sha512-6YctwVsmlkchxfGUogvVrrhzyD3grFJyluj5JgDlQrwfMLJSt5tdAzFZfPf4H2Xoi5YLcQ6BxfJlaOBHuctyIw==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.3.tgz",
+      "integrity": "sha512-BnEfi5+6J2Lte9LeiL6TxLWdIlEv9Woacc1qXzXBgbikcOzMRM2Oya5XGg/f/ngotv1ej2A/b+3iJH8wbS1+lQ==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.12.13",
         "@babel/helper-function-name": "^7.14.2",
         "@babel/helper-member-expression-to-functions": "^7.13.12",
         "@babel/helper-optimise-call-expression": "^7.12.13",
-        "@babel/helper-replace-supers": "^7.13.12",
+        "@babel/helper-replace-supers": "^7.14.3",
         "@babel/helper-split-export-declaration": "^7.12.13"
       }
     },
     "@babel/helper-create-regexp-features-plugin": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.17.tgz",
-      "integrity": "sha512-p2VGmBu9oefLZ2nQpgnEnG0ZlRPvL8gAGvPUMQwUdaE8k49rOMuZpOwdQoy5qJf6K8jL3bcAMhVUlHAjIgJHUg==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.14.3.tgz",
+      "integrity": "sha512-JIB2+XJrb7v3zceV2XzDhGIB902CmKGSpSl4q2C6agU9SNLG/2V1RtFRGPG1Ajh9STj3+q6zJMOC+N/pp2P9DA==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.12.13",
         "regexpu-core": "^4.7.1"
       }
     },
     "@babel/helper-define-polyfill-provider": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.0.tgz",
-      "integrity": "sha512-JT8tHuFjKBo8NnaUbblz7mIu1nnvUDiHVjXXkulZULyidvo/7P6TY7+YqpV37IfF+KUFxmlK04elKtGKXaiVgw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.1.tgz",
+      "integrity": "sha512-x3AUTVZNPunaw1opRTa5OwVA5N0YxGlIad9xQ5QflK1uIS7PnAGGU5O2Dj/G183fR//N8AzTq+Q8+oiu9m0VFg==",
       "requires": {
         "@babel/helper-compilation-targets": "^7.13.0",
         "@babel/helper-module-imports": "^7.12.13",
@@ -224,14 +224,14 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
-      "integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.3.tgz",
+      "integrity": "sha512-Rlh8qEWZSTfdz+tgNV/N4gz1a0TMNwCUcENhMjHTHKp3LseYH5Jha0NSlyTQWMnjbYcwFt+bqAMqSLHVXkQ6UA==",
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.13.12",
         "@babel/helper-optimise-call-expression": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.12"
+        "@babel/traverse": "^7.14.2",
+        "@babel/types": "^7.14.2"
       }
     },
     "@babel/helper-simple-access": {
@@ -317,9 +317,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.2.tgz",
-      "integrity": "sha512-IoVDIHpsgE/fu7eXBeRWt8zLbDrSvD7H1gpomOkPpBoEN8KCruCqSDdqo8dddwQQrui30KSvQBaMUOJiuFu6QQ=="
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.3.tgz",
+      "integrity": "sha512-7MpZDIfI7sUC5zWo2+foJ50CSI5lcqDehZ0lVgIhSi4bFEk94fLAKlF3Q0nzSQQ+ca0lm+O6G9ztKVBeu8PMRQ=="
     },
     "@babel/plugin-external-helpers": {
       "version": "7.12.13",
@@ -856,15 +856,15 @@
       }
     },
     "@babel/plugin-transform-react-jsx": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.13.12.tgz",
-      "integrity": "sha512-jcEI2UqIcpCqB5U5DRxIl0tQEProI2gcu+g8VTIqxLO5Iidojb4d77q+fwGseCvd8af/lJ9masp4QWzBXFE2xA==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.3.tgz",
+      "integrity": "sha512-uuxuoUNVhdgYzERiHHFkE4dWoJx+UFVyuAl0aqN8P2/AKFHwqgUC5w2+4/PjpKXJsFgBlYAFXlUmDQ3k3DUkXw==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.12.13",
         "@babel/helper-module-imports": "^7.13.12",
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/plugin-syntax-jsx": "^7.12.13",
-        "@babel/types": "^7.13.12"
+        "@babel/types": "^7.14.2"
       }
     },
     "@babel/plugin-transform-react-jsx-self": {
@@ -900,9 +900,9 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.14.2.tgz",
-      "integrity": "sha512-LyA2AiPkaYzI7G5e2YI4NCasTfFe7mZvlupNprDOB7CdNUHb2DQC4uV6oeZ0396gOcicUzUCh0MShL6wiUgk+Q==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.14.3.tgz",
+      "integrity": "sha512-t960xbi8wpTFE623ef7sd+UpEC5T6EEguQlTBJDEO05+XwnIWVfuqLw/vdLWY6IdFmtZE+65CZAfByT39zRpkg==",
       "requires": {
         "@babel/helper-module-imports": "^7.13.12",
         "@babel/helper-plugin-utils": "^7.13.0",
@@ -961,11 +961,11 @@
       }
     },
     "@babel/plugin-transform-typescript": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.13.0.tgz",
-      "integrity": "sha512-elQEwluzaU8R8dbVuW2Q2Y8Nznf7hnjM7+DSCd14Lo5fF63C9qNLbwZYbmZrtV9/ySpSUpkRpQXvJb6xyu4hCQ==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.14.3.tgz",
+      "integrity": "sha512-G5Bb5pY6tJRTC4ag1visSgiDoGgJ1u1fMUgmc2ijLkcIdzP83Q1qyZX4ggFQ/SkR+PNOatkaYC+nKcTlpsX4ag==",
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.13.0",
+        "@babel/helper-create-class-features-plugin": "^7.14.3",
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/plugin-syntax-typescript": "^7.12.13"
       }
@@ -1223,15 +1223,15 @@
       }
     },
     "@expo/config": {
-      "version": "3.3.41",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-3.3.41.tgz",
-      "integrity": "sha512-9WfgWK4UM85prRw83WiP7jU8X86GzSSCaThcNeKDVycfA4sqcyei0py9XA2rYH6X9bCTJZxntb4BRGRffcMJXA==",
+      "version": "3.3.42",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-3.3.42.tgz",
+      "integrity": "sha512-BLFp9JvMHkBFutwKM+o9RhvmdllSyQpswvY9974Y8gjYsO5/BXfvT5J0GyUt1bdtqGyA8dlfo5jew/mtkeStRA==",
       "requires": {
         "@babel/core": "7.9.0",
         "@babel/plugin-proposal-class-properties": "~7.12.13",
         "@babel/preset-env": "~7.12.13",
         "@babel/preset-typescript": "~7.12.13",
-        "@expo/config-plugins": "1.0.31",
+        "@expo/config-plugins": "1.0.32",
         "@expo/config-types": "^40.0.0-beta.2",
         "@expo/json-file": "8.2.30",
         "fs-extra": "9.0.0",
@@ -1244,9 +1244,9 @@
       }
     },
     "@expo/config-plugins": {
-      "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-1.0.31.tgz",
-      "integrity": "sha512-fouUPEXPhMcrxLL9SnbtJc9AtRW2Olt0Qrv6O0OqspwMt6g5DwG4qtRnoUdGNVHAQ3X3YskESd8bw6VGT6QA3A==",
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-1.0.32.tgz",
+      "integrity": "sha512-goQoBvWYq1fk/jdDYYioN5gYlEhmPVRP6Y9jxmCLTHoHhZHSI+Pl5BXidUqVNdE2XFhoiz9yLbjQrGgYFPXuwQ==",
       "requires": {
         "@expo/config-types": "^40.0.0-beta.2",
         "@expo/configure-splash-screen": "0.4.0",
@@ -1332,11 +1332,11 @@
       }
     },
     "@expo/metro-config": {
-      "version": "0.1.67",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.1.67.tgz",
-      "integrity": "sha512-0OQ9X2OEX2nvWGOgl0LDZk5uHk2L2wQ2Is+GzUc/thH0g9QqakuT0SlqBWZ1HznB0ATpLECXjTlzVw59UOA/9w==",
+      "version": "0.1.68",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.1.68.tgz",
+      "integrity": "sha512-jxcGOCPUK9SiHqX9LB0c7N9LbasDIUYghqC6xc0VUS+8ZmbDZZ/QFjeKUJbHjjXsZG+jSGcft37PdUf4Mrcbzg==",
       "requires": {
-        "@expo/config": "3.3.41",
+        "@expo/config": "3.3.42",
         "chalk": "^4.1.0",
         "getenv": "^1.0.0",
         "metro-react-native-babel-transformer": "^0.59.0"
@@ -4257,13 +4257,13 @@
       }
     },
     "@sentry/browser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.4.0.tgz",
-      "integrity": "sha512-HF7O6Vf2hr4uFbT8Ww60tnGJhfANPlNRrj7mhPZGiBYKycfz+z0PgvrQpW2HAHGhcfeJv5dpUY5N2t25cFx8mQ==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.4.1.tgz",
+      "integrity": "sha512-3cDud6GWutnJqcnheIq0lPNTsUJbrRLevQ+g1YfawVXFUxfmmY2bOsGd/Mxq17LxYeBHgKTitXv3DU1bsQ+WBQ==",
       "requires": {
-        "@sentry/core": "6.4.0",
-        "@sentry/types": "6.4.0",
-        "@sentry/utils": "6.4.0",
+        "@sentry/core": "6.4.1",
+        "@sentry/types": "6.4.1",
+        "@sentry/utils": "6.4.1",
         "tslib": "^1.9.3"
       }
     },
@@ -4281,45 +4281,45 @@
       }
     },
     "@sentry/core": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.4.0.tgz",
-      "integrity": "sha512-m93z4lCcXLZQfKBf1lqIHoZPaxQ3JETYuh1iwylvKS4LSMTf/6rFacPkNpvD/qx53ejD+lhgs9YCHLlZvkn3+g==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.4.1.tgz",
+      "integrity": "sha512-Lx13oTiP+Tjvm5VxulcCszNVd2S1wY4viSnr+ygq62ySVERR+t7uOZDSARZ0rZ259GwW6nkbMh9dDmD0d6VCGQ==",
       "requires": {
-        "@sentry/hub": "6.4.0",
-        "@sentry/minimal": "6.4.0",
-        "@sentry/types": "6.4.0",
-        "@sentry/utils": "6.4.0",
+        "@sentry/hub": "6.4.1",
+        "@sentry/minimal": "6.4.1",
+        "@sentry/types": "6.4.1",
+        "@sentry/utils": "6.4.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.4.0.tgz",
-      "integrity": "sha512-8MlXuyMl+Qe+tmKS0lnfGDLZLig/8LTG+hhe8hnAN8WXPBntgzyx3EfPgWSNY8eOuJMAVhQKrfjhWAxyGD2jjg==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.4.1.tgz",
+      "integrity": "sha512-7IZRP5buDE6s/c3vWzzPR/ySE+8GUuHPgTEPiDCPOCWwUN11zXDafJDKkJqY3muJfebUKmC/JG67RyBx+XlnlQ==",
       "requires": {
-        "@sentry/types": "6.4.0",
-        "@sentry/utils": "6.4.0",
+        "@sentry/types": "6.4.1",
+        "@sentry/utils": "6.4.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/integrations": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.4.0.tgz",
-      "integrity": "sha512-RWSXzliop0+qNa2oKEM4MsRz3/odxXepbTrIH/B2xDNQfjaSCD1dbuXD7SXnrAMatT3GLbL9GAorBMs7r/CsYg==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.4.1.tgz",
+      "integrity": "sha512-3kw6NcrFGXW+qlfT112EkYt7jdFX55m9yJN5eCt7Iad59YzA8ji8Pio5ohy9Pl+OfYXlKRFOvnYPpZZn80UjlQ==",
       "requires": {
-        "@sentry/types": "6.4.0",
-        "@sentry/utils": "6.4.0",
+        "@sentry/types": "6.4.1",
+        "@sentry/utils": "6.4.1",
         "localforage": "^1.8.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.4.0.tgz",
-      "integrity": "sha512-HehBOSEKgAupYYkcoxGyaX3N8FX9V+QOuoQf+qaKq6bULjUgKU9101fUKLmT+qAfvYPgQhb8mJ3c8S/pdSztOA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.4.1.tgz",
+      "integrity": "sha512-4x/PRbDZACCKJqjta9EkhiIMyGMf7VgBX13EEWEDVWLP7ymFukBuTr4ap/Tz9429kB/yXZuDGGMIZp/G618H3g==",
       "requires": {
-        "@sentry/hub": "6.4.0",
-        "@sentry/types": "6.4.0",
+        "@sentry/hub": "6.4.1",
+        "@sentry/types": "6.4.1",
         "tslib": "^1.9.3"
       }
     },
@@ -4530,16 +4530,16 @@
       }
     },
     "@sentry/types": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.4.0.tgz",
-      "integrity": "sha512-kwFkb+fCoZyHHuSIW/T+pzifkxDCmi6extvtYxa6YtVgl/mZIom9yme0uQFy4EdYLIBZ+9IQDGtQmNMKrVIdKQ=="
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.4.1.tgz",
+      "integrity": "sha512-sTu/GaLsLYk1AkAqpkMT4+4q665LtZjhV0hkgiTD4N3zPl5uSf1pCIzxPRYjOpe7NEANmWv8U4PaGKGtc2eMfA=="
     },
     "@sentry/utils": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.4.0.tgz",
-      "integrity": "sha512-82cF5dpaM8lDyeztOjL7ZLDFgzJHDoc1m8LlZXxf9gWvOybH7uCe3WasC9qK1lHYMrh1Z9Qfqe+mJBdxm3QzJw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.4.1.tgz",
+      "integrity": "sha512-xJ1uVa5fvg23pXQfulvCIBb9pQ3p1awyd1PapK2AYi+wKjTuYl4B9edmhjRREEQEExznl/d2OVm78fRXLq7M9Q==",
       "requires": {
-        "@sentry/types": "6.4.0",
+        "@sentry/types": "6.4.1",
         "tslib": "^1.9.3"
       }
     },
@@ -4938,9 +4938,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.0.tgz",
-      "integrity": "sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ=="
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz",
+      "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -5007,13 +5007,13 @@
       "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA=="
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.23.0.tgz",
-      "integrity": "sha512-tGK1y3KIvdsQEEgq6xNn1DjiFJtl+wn8JJQiETtCbdQxw1vzjXyAaIkEmO2l6Nq24iy3uZBMFQjZ6ECf1QdgGw==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.25.0.tgz",
+      "integrity": "sha512-Qfs3dWkTMKkKwt78xp2O/KZQB8MPS1UQ5D3YW2s6LQWBE1074BE+Rym+b1pXZIX3M3fSvPUDaCvZLKV2ylVYYQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.23.0",
-        "@typescript-eslint/scope-manager": "4.23.0",
+        "@typescript-eslint/experimental-utils": "4.25.0",
+        "@typescript-eslint/scope-manager": "4.25.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "lodash": "^4.17.15",
@@ -5023,55 +5023,55 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.23.0.tgz",
-      "integrity": "sha512-WAFNiTDnQfrF3Z2fQ05nmCgPsO5o790vOhmWKXbbYQTO9erE1/YsFot5/LnOUizLzU2eeuz6+U/81KV5/hFTGA==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.25.0.tgz",
+      "integrity": "sha512-f0doRE76vq7NEEU0tw+ajv6CrmPelw5wLoaghEHkA2dNLFb3T/zJQqGPQ0OYt5XlZaS13MtnN+GTPCuUVg338w==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.23.0",
-        "@typescript-eslint/types": "4.23.0",
-        "@typescript-eslint/typescript-estree": "4.23.0",
+        "@typescript-eslint/scope-manager": "4.25.0",
+        "@typescript-eslint/types": "4.25.0",
+        "@typescript-eslint/typescript-estree": "4.25.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.23.0.tgz",
-      "integrity": "sha512-wsvjksHBMOqySy/Pi2Q6UuIuHYbgAMwLczRl4YanEPKW5KVxI9ZzDYh3B5DtcZPQTGRWFJrfcbJ6L01Leybwug==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.25.0.tgz",
+      "integrity": "sha512-OZFa1SKyEJpAhDx8FcbWyX+vLwh7OEtzoo2iQaeWwxucyfbi0mT4DijbOSsTgPKzGHr6GrF2V5p/CEpUH/VBxg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.23.0",
-        "@typescript-eslint/types": "4.23.0",
-        "@typescript-eslint/typescript-estree": "4.23.0",
+        "@typescript-eslint/scope-manager": "4.25.0",
+        "@typescript-eslint/types": "4.25.0",
+        "@typescript-eslint/typescript-estree": "4.25.0",
         "debug": "^4.1.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.23.0.tgz",
-      "integrity": "sha512-ZZ21PCFxPhI3n0wuqEJK9omkw51wi2bmeKJvlRZPH5YFkcawKOuRMQMnI8mH6Vo0/DoHSeZJnHiIx84LmVQY+w==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.25.0.tgz",
+      "integrity": "sha512-2NElKxMb/0rya+NJG1U71BuNnp1TBd1JgzYsldsdA83h/20Tvnf/HrwhiSlNmuq6Vqa0EzidsvkTArwoq+tH6w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.23.0",
-        "@typescript-eslint/visitor-keys": "4.23.0"
+        "@typescript-eslint/types": "4.25.0",
+        "@typescript-eslint/visitor-keys": "4.25.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.23.0.tgz",
-      "integrity": "sha512-oqkNWyG2SLS7uTWLZf6Sr7Dm02gA5yxiz1RP87tvsmDsguVATdpVguHr4HoGOcFOpCvx9vtCSCyQUGfzq28YCw==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.25.0.tgz",
+      "integrity": "sha512-+CNINNvl00OkW6wEsi32wU5MhHti2J25TJsJJqgQmJu3B3dYDBcmOxcE5w9cgoM13TrdE/5ND2HoEnBohasxRQ==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.23.0.tgz",
-      "integrity": "sha512-5Sty6zPEVZF5fbvrZczfmLCOcby3sfrSPu30qKoY1U3mca5/jvU5cwsPb/CO6Q3ByRjixTMIVsDkqwIxCf/dMw==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.25.0.tgz",
+      "integrity": "sha512-1B8U07TGNAFMxZbSpF6jqiDs1cVGO0izVkf18Q/SPcUAc9LhHxzvSowXDTvkHMWUVuPpagupaW63gB6ahTXVlg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.23.0",
-        "@typescript-eslint/visitor-keys": "4.23.0",
+        "@typescript-eslint/types": "4.25.0",
+        "@typescript-eslint/visitor-keys": "4.25.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -5080,12 +5080,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.23.0.tgz",
-      "integrity": "sha512-5PNe5cmX9pSifit0H+nPoQBXdbNzi5tOEec+3riK+ku4e3er37pKxMKDH5Ct5Y4fhWxcD4spnlYjxi9vXbSpwg==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.25.0.tgz",
+      "integrity": "sha512-AmkqV9dDJVKP/TcZrbf6s6i1zYXt5Hl8qOLrRDTFfRNae4+LB8A4N3i+FLZPW85zIxRy39BgeWOfMS3HoH5ngg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.23.0",
+        "@typescript-eslint/types": "4.25.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -5317,9 +5317,9 @@
       "dev": true
     },
     "array-filter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
-      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
     },
     "array-includes": {
       "version": "3.1.3",
@@ -5359,6 +5359,18 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+    },
+    "array.prototype.filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.0.tgz",
+      "integrity": "sha512-TfO1gz+tLm+Bswq0FBOXPqAchtCr2Rn48T8dLJoRFl8NoEosjZmzptmuo1X8aZBzZcqsR1W8U761tjACJtngTQ==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "is-string": "^1.0.5"
+      }
     },
     "array.prototype.flat": {
       "version": "1.2.4",
@@ -5438,11 +5450,11 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "available-typed-arrays": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
-      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.3.tgz",
+      "integrity": "sha512-CuPhFULixV/d89POo1UG4GqGbR7dmrefY2ZdmsYakeR4gOSJXoF7tfeaiqMHGOMrlTiJoeEs87fpLsBYmE2BMw==",
       "requires": {
-        "array-filter": "^1.0.0"
+        "array.prototype.filter": "^1.0.0"
       }
     },
     "aws-sign2": {
@@ -5617,12 +5629,12 @@
       }
     },
     "babel-plugin-polyfill-corejs2": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.0.tgz",
-      "integrity": "sha512-9bNwiR0dS881c5SHnzCmmGlMkJLl0OUZvxrxHo9w/iNoRuqaPjqlvBf4HrovXtQs/au5yKkpcdgfT1cC5PAZwg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.1.tgz",
+      "integrity": "sha512-hXGSPbr6IbjeMyGew+3uGIAkRjBFSOJ9FLDZNOfHuyJZCcoia4nd/72J0bSgvfytcVfUcP/dxEVcUhVJuQRtSw==",
       "requires": {
         "@babel/compat-data": "^7.13.11",
-        "@babel/helper-define-polyfill-provider": "^0.2.0",
+        "@babel/helper-define-polyfill-provider": "^0.2.1",
         "semver": "^6.1.1"
       },
       "dependencies": {
@@ -5634,20 +5646,20 @@
       }
     },
     "babel-plugin-polyfill-corejs3": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.0.tgz",
-      "integrity": "sha512-zZyi7p3BCUyzNxLx8KV61zTINkkV65zVkDAFNZmrTCRVhjo1jAS+YLvDJ9Jgd/w2tsAviCwFHReYfxO3Iql8Yg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.1.tgz",
+      "integrity": "sha512-WZCqF3DLUhdTD/P381MDJfuP18hdCZ+iqJ+wHtzhWENpsiof284JJ1tMQg1CE+hfCWyG48F7e5gDMk2c3Laz7w==",
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.2.0",
+        "@babel/helper-define-polyfill-provider": "^0.2.1",
         "core-js-compat": "^3.9.1"
       }
     },
     "babel-plugin-polyfill-regenerator": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.0.tgz",
-      "integrity": "sha512-J7vKbCuD2Xi/eEHxquHN14bXAW9CXtecwuLrOIDJtcZzTaPzV1VdEfoUf9AzcRBMolKUQKM9/GVojeh0hFiqMg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.1.tgz",
+      "integrity": "sha512-T3bYyL3Sll2EtC94v3f+fA8M28q7YPTOZdB++SRHjvYZTvtd+WorMUq3tDTD4Q7Kjk1LG0gGromslKjcO5p2TA==",
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.2.0"
+        "@babel/helper-define-polyfill-provider": "^0.2.1"
       }
     },
     "babel-plugin-react-native-web": {
@@ -5692,9 +5704,9 @@
       }
     },
     "babel-preset-fbjs": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.3.0.tgz",
-      "integrity": "sha512-7QTLTCd2gwB2qGoi5epSULMHugSVgpcVt5YAeiFO9ABLrutDQzKfGwzxgZHLpugq8qMdg/DhRZDZ5CLKxBkEbw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.4.0.tgz",
+      "integrity": "sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==",
       "requires": {
         "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
@@ -6360,16 +6372,6 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
-    "contains-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-1.0.0.tgz",
-      "integrity": "sha1-NFizMhhWA+ju0Y9RjUoQiIo6vJE=",
-      "dev": true,
-      "requires": {
-        "normalize-path": "^2.1.1",
-        "path-starts-with": "^1.0.0"
-      }
-    },
     "convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -6723,9 +6725,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.728",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.728.tgz",
-      "integrity": "sha512-SHv4ziXruBpb1Nz4aTuqEHBYi/9GNCJMYIJgDEXrp/2V01nFXMNFUTli5Z85f5ivSkioLilQatqBYFB44wNJrA=="
+      "version": "1.3.738",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.738.tgz",
+      "integrity": "sha512-vCMf4gDOpEylPSLPLSwAEsz+R3ShP02Y3cAKMZvTqule3XcPp7tgc/0ESI7IS6ZeyBlGClE50N53fIOkcIVnpw=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -6829,6 +6831,11 @@
         "string.prototype.trimstart": "^1.0.4",
         "unbox-primitive": "^1.0.0"
       }
+    },
+    "es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
     },
     "es-get-iterator": {
       "version": "1.1.2",
@@ -6939,9 +6946,9 @@
       }
     },
     "eslint": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.26.0.tgz",
-      "integrity": "sha512-4R1ieRf52/izcZE7AlLy56uIHHDLT74Yzz2Iv2l6kDaYvEu9x+wMB5dZArVL8SYGXSYV2YAg70FcW5Y5nGGNIg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.27.0.tgz",
+      "integrity": "sha512-JZuR6La2ZF0UD384lcbnd0Cgg6QJjiCwhMD6eU4h/VGPcVGwawNNzKU41tgokGXnfjOOyI6QIffthhJTPzzuRA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
@@ -6952,12 +6959,14 @@
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
+        "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^2.1.0",
         "eslint-visitor-keys": "^2.0.0",
         "espree": "^7.3.1",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
@@ -6969,7 +6978,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.21",
+        "lodash.merge": "^4.6.2",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -6978,7 +6987,7 @@
         "semver": "^7.2.1",
         "strip-ansi": "^6.0.0",
         "strip-json-comments": "^3.1.0",
-        "table": "^6.0.4",
+        "table": "^6.0.9",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
@@ -7193,14 +7202,13 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.23.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.2.tgz",
-      "integrity": "sha512-LmNoRptHBxOP+nb0PIKz1y6OSzCJlB+0g0IGS3XV4KaKk2q4szqQ6s6F1utVf5ZRkxk/QOTjdxe7v4VjS99Bsg==",
+      "version": "2.23.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.3.tgz",
+      "integrity": "sha512-wDxdYbSB55F7T5CC7ucDjY641VvKmlRwT0Vxh7PkY1mI4rclVRFWYfsrjDgZvwYYDZ5ee0ZtfFKXowWjqvEoRQ==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.3",
         "array.prototype.flat": "^1.2.4",
-        "contains-path": "^1.0.0",
         "debug": "^2.6.9",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.4",
@@ -7739,11 +7747,34 @@
       }
     },
     "expo-device": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/expo-device/-/expo-device-3.2.0.tgz",
-      "integrity": "sha512-MPtyut6bMlT8Gu3AH5VsXeF2DiulcnG3Q9q1LosruCBDdcTcDpXDXMaN0ZgTjWKOVgoMVkkR5e5WxZcS9Qlj9g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/expo-device/-/expo-device-2.4.0.tgz",
+      "integrity": "sha512-mxBiX6nvvtbKot3Kmmb2y8lo4Ki8jWGdUnpC2OX70Yiy75c8mOVbHUe2VMEnx3SysXycwvC5KzJSDy+PuDqovg==",
       "requires": {
+        "fbjs": "1.0.0",
         "ua-parser-js": "^0.7.19"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+        },
+        "fbjs": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+          "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+          "requires": {
+            "core-js": "^2.4.1",
+            "fbjs-css-vars": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        }
       }
     },
     "expo-error-recovery": {
@@ -8719,9 +8750,9 @@
       "dev": true
     },
     "iconv-lite": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
-      "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
@@ -13336,6 +13367,12 @@
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
     "lodash.omit": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
@@ -14771,15 +14808,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
-    "path-starts-with": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/path-starts-with/-/path-starts-with-1.0.0.tgz",
-      "integrity": "sha1-soJDAV6LE43lcmgqxS2kLmRq2E4=",
-      "dev": true,
-      "requires": {
-        "normalize-path": "^2.1.1"
-      }
-    },
     "path-to-regexp": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
@@ -14815,9 +14843,9 @@
       "integrity": "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA=="
     },
     "picomatch": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
-      "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "dev": true
     },
     "pify": {
@@ -15216,9 +15244,9 @@
       }
     },
     "react-devtools-core": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.13.2.tgz",
-      "integrity": "sha512-/lA5FVLMhUHrkQwtEf5wZNCKsXmc2RBZMNS/kkq3WlXPg2Y7COUGMh0Lmz34jjMpM0kvLMDuj+DqsPT/jSADbw==",
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.13.4.tgz",
+      "integrity": "sha512-su/lI4LdiK5P1YgZpbm8K1iNQX6s0Lq5fJLa1ZcnpewvrqP5V14svHrbPmrU5ptMUSiwjZ3/CBmc/JCZOuuiHQ==",
       "requires": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
@@ -16145,9 +16173,9 @@
       }
     },
     "sentry-expo": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/sentry-expo/-/sentry-expo-3.1.4.tgz",
-      "integrity": "sha512-BQFpXnGXLo6SacuwHGDs8UvRKqov0hkTHqp3BmX+w87J7/HH8OchmzOsbrNu6arO0+SLppbaXLjlMd3yWin1Qg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/sentry-expo/-/sentry-expo-3.1.3.tgz",
+      "integrity": "sha512-f4sjfJeIH9dXJAW5xOKcazbAN3HKB2DnLk6Hrlaf47/2pinKwEObOWSqrJVVPRw9LGAKS4lrZtTVwYFbkeXXlw==",
       "requires": {
         "@expo/config-plugins": "~1.0.13",
         "@expo/config-types": "^40.0.0-beta.2",
@@ -16156,14 +16184,49 @@
         "@sentry/integrations": "^6.2.0",
         "@sentry/react-native": "^2.2.1",
         "@sentry/types": "^6.2.0",
-        "expo-application": "~3.1.2",
-        "expo-constants": "~10.1.3",
-        "expo-device": "~3.2.0",
+        "expo-application": "^2.2.1",
+        "expo-constants": "^9.3.5",
+        "expo-device": "^2.4.0",
         "expo-updates": "~0.3.5",
         "mkdirp": "^1.0.3",
         "rimraf": "^2.6.1"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+        },
+        "expo-application": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-2.4.1.tgz",
+          "integrity": "sha512-VHDvXz55LIYdLoE1aR0AFycB1jz4ggbMToUbKAbCEjro+PdUNm/Gj8gQeFgH6wL2oAztQH4qJ+uiOwrw8SFK+Q=="
+        },
+        "expo-constants": {
+          "version": "9.3.5",
+          "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-9.3.5.tgz",
+          "integrity": "sha512-qIlv2ffSjQl3wrvJwXYoNfQNfH/sK46EXcgyEQnQ1SAQO4ukwTEpG9j3fdW6aTiVEVrv/DsA1IaVRqKrUwSd3A==",
+          "requires": {
+            "@expo/config": "^3.3.18",
+            "fbjs": "1.0.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "fbjs": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+          "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+          "requires": {
+            "core-js": "^2.4.1",
+            "fbjs-css-vars": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        },
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -16253,13 +16316,6 @@
         "array-map": "~0.0.0",
         "array-reduce": "~0.0.0",
         "jsonify": "~0.0.0"
-      },
-      "dependencies": {
-        "array-filter": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-          "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
-        }
       }
     },
     "shellwords": {
@@ -16534,9 +16590,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.8.tgz",
-      "integrity": "sha512-NDgA96EnaLSvtbM7trJj+t1LUR3pirkDCcz9nOUlPb5DMBGsH7oES6C3hs3j7R9oHEa1EMvReS/BUAIT5Tcr0g==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
+      "integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==",
       "dev": true
     },
     "split-on-first": {
@@ -16824,9 +16880,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.4.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.4.0.tgz",
-          "integrity": "sha512-7QD2l6+KBSLwf+7MuYocbWvRPdOu63/trReTLu2KFwkgctnub1auoF+Y1WYcm09CTM7quuscrzqmASaLHC/K4Q==",
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
+          "integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7746,34 +7746,11 @@
       }
     },
     "expo-device": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/expo-device/-/expo-device-2.4.0.tgz",
-      "integrity": "sha512-mxBiX6nvvtbKot3Kmmb2y8lo4Ki8jWGdUnpC2OX70Yiy75c8mOVbHUe2VMEnx3SysXycwvC5KzJSDy+PuDqovg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/expo-device/-/expo-device-3.2.0.tgz",
+      "integrity": "sha512-MPtyut6bMlT8Gu3AH5VsXeF2DiulcnG3Q9q1LosruCBDdcTcDpXDXMaN0ZgTjWKOVgoMVkkR5e5WxZcS9Qlj9g==",
       "requires": {
-        "fbjs": "1.0.0",
         "ua-parser-js": "^0.7.19"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.12",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-        },
-        "fbjs": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
-          "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
-          "requires": {
-            "core-js": "^2.4.1",
-            "fbjs-css-vars": "^1.0.0",
-            "isomorphic-fetch": "^2.1.1",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.18"
-          }
-        }
       }
     },
     "expo-error-recovery": {
@@ -14803,9 +14780,9 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp": {
       "version": "1.8.0",
@@ -16172,9 +16149,9 @@
       }
     },
     "sentry-expo": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/sentry-expo/-/sentry-expo-3.1.3.tgz",
-      "integrity": "sha512-f4sjfJeIH9dXJAW5xOKcazbAN3HKB2DnLk6Hrlaf47/2pinKwEObOWSqrJVVPRw9LGAKS4lrZtTVwYFbkeXXlw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/sentry-expo/-/sentry-expo-3.1.4.tgz",
+      "integrity": "sha512-BQFpXnGXLo6SacuwHGDs8UvRKqov0hkTHqp3BmX+w87J7/HH8OchmzOsbrNu6arO0+SLppbaXLjlMd3yWin1Qg==",
       "requires": {
         "@expo/config-plugins": "~1.0.13",
         "@expo/config-types": "^40.0.0-beta.2",
@@ -16183,49 +16160,14 @@
         "@sentry/integrations": "^6.2.0",
         "@sentry/react-native": "^2.2.1",
         "@sentry/types": "^6.2.0",
-        "expo-application": "^2.2.1",
-        "expo-constants": "^9.3.5",
-        "expo-device": "^2.4.0",
+        "expo-application": "~3.1.2",
+        "expo-constants": "~10.1.3",
+        "expo-device": "~3.2.0",
         "expo-updates": "~0.3.5",
         "mkdirp": "^1.0.3",
         "rimraf": "^2.6.1"
       },
       "dependencies": {
-        "core-js": {
-          "version": "2.6.12",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-        },
-        "expo-application": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-2.4.1.tgz",
-          "integrity": "sha512-VHDvXz55LIYdLoE1aR0AFycB1jz4ggbMToUbKAbCEjro+PdUNm/Gj8gQeFgH6wL2oAztQH4qJ+uiOwrw8SFK+Q=="
-        },
-        "expo-constants": {
-          "version": "9.3.5",
-          "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-9.3.5.tgz",
-          "integrity": "sha512-qIlv2ffSjQl3wrvJwXYoNfQNfH/sK46EXcgyEQnQ1SAQO4ukwTEpG9j3fdW6aTiVEVrv/DsA1IaVRqKrUwSd3A==",
-          "requires": {
-            "@expo/config": "^3.3.18",
-            "fbjs": "1.0.0",
-            "uuid": "^3.3.2"
-          }
-        },
-        "fbjs": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
-          "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
-          "requires": {
-            "core-js": "^2.4.1",
-            "fbjs-css-vars": "^1.0.0",
-            "isomorphic-fetch": "^2.1.1",
-            "loose-envify": "^1.0.0",
-            "object-assign": "^4.1.0",
-            "promise": "^7.1.1",
-            "setimmediate": "^1.0.5",
-            "ua-parser-js": "^0.7.18"
-          }
-        },
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,9 +113,9 @@
       }
     },
     "@babel/helper-define-polyfill-provider": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.1.tgz",
-      "integrity": "sha512-x3AUTVZNPunaw1opRTa5OwVA5N0YxGlIad9xQ5QflK1uIS7PnAGGU5O2Dj/G183fR//N8AzTq+Q8+oiu9m0VFg==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.3.tgz",
+      "integrity": "sha512-RH3QDAfRMzj7+0Nqu5oqgO5q9mFtQEVvCRsi8qCEfzLR9p2BHfn5FzhSB2oj1fF7I2+DcTORkYaQ6aTR9Cofew==",
       "requires": {
         "@babel/helper-compilation-targets": "^7.13.0",
         "@babel/helper-module-imports": "^7.12.13",
@@ -1223,15 +1223,15 @@
       }
     },
     "@expo/config": {
-      "version": "3.3.43",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-3.3.43.tgz",
-      "integrity": "sha512-5a78fQqTKk7RhgrW5XzHS8ylCo9YRjZrheLyVDNNfvwAD8YjeBz6bFWsItZPpAIoaDgkLh0a8uhc11DCmqoKpw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-4.0.0.tgz",
+      "integrity": "sha512-Hy2/49BMMzziDhJFf+N0gG5znLuhoorS9/+OFO7wqDbRV4LRraNx4UuGdyY06yLI7F0BgEJBGy109pZ4LZoKrA==",
       "requires": {
         "@babel/core": "7.9.0",
         "@babel/plugin-proposal-class-properties": "~7.12.13",
         "@babel/preset-env": "~7.12.13",
         "@babel/preset-typescript": "~7.12.13",
-        "@expo/config-plugins": "1.0.33",
+        "@expo/config-plugins": "2.0.0",
         "@expo/config-types": "^40.0.0-beta.2",
         "@expo/json-file": "8.2.30",
         "fs-extra": "9.0.0",
@@ -1244,13 +1244,11 @@
       }
     },
     "@expo/config-plugins": {
-      "version": "1.0.33",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-1.0.33.tgz",
-      "integrity": "sha512-YQJop0c69LKD/6ZJJto7klS7TDmzgs44TI0Z5RBqesOjYlDwNFcQk2Rl2BaA1wlAYkH+rRrhN2+WjjSyD9HiPg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-2.0.0.tgz",
+      "integrity": "sha512-MyD9cdoVuXEw/xzpHiFNzRvMFi1DWTU2oShTTviA8xt1U1gyuBTa9aBwFSyvZmpMoCEscOsC8ED0sZl7LM5wNw==",
       "requires": {
         "@expo/config-types": "^40.0.0-beta.2",
-        "@expo/configure-splash-screen": "0.4.0",
-        "@expo/image-utils": "0.3.14",
         "@expo/json-file": "8.2.30",
         "@expo/plist": "0.0.13",
         "find-up": "~5.0.0",
@@ -1331,11 +1329,11 @@
       }
     },
     "@expo/metro-config": {
-      "version": "0.1.69",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.1.69.tgz",
-      "integrity": "sha512-Py1Zovxl5Esy09xewnOytOPgt5xC+QWP7bgvF4VML6EE05e7Qrz3VnLZJxJA8H0hGJc6/ctwO5tttctZpf1qwQ==",
+      "version": "0.1.70",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.1.70.tgz",
+      "integrity": "sha512-zegpHSI0EedKSXkBg0wtU99YYA6OY8qCgm0urdKszDJ9c8Oea26b2+x2j0PBqspUiTC4kY+t/pzZkKWDEFAquQ==",
       "requires": {
-        "@expo/config": "3.3.43",
+        "@expo/config": "4.0.0",
         "chalk": "^4.1.0",
         "getenv": "^1.0.0",
         "metro-react-native-babel-transformer": "^0.59.0"
@@ -1349,13 +1347,6 @@
         "base64-js": "^1.2.3",
         "xmlbuilder": "^14.0.0",
         "xmldom": "~0.5.0"
-      },
-      "dependencies": {
-        "xmlbuilder": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-14.0.0.tgz",
-          "integrity": "sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg=="
-        }
       }
     },
     "@expo/spawn-async": {
@@ -4267,9 +4258,9 @@
       }
     },
     "@sentry/cli": {
-      "version": "1.64.2",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.64.2.tgz",
-      "integrity": "sha512-hBF8cswn878W7YqAgeg/vcQ51BgtpeiklGV6Q5MEXqGXtbjaKTBYBcKTkhzpkkcUtTu5bFkVcdGzVtpl4oBe+g==",
+      "version": "1.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.65.0.tgz",
+      "integrity": "sha512-N5riXQ7H+tGMQ+VCEVJI8Qy4FoVDvDw7jmFYbcn5xLWTyM+g0rVEm7kUL33zZENxdL2plNlepklPU+rFk4KDRw==",
       "requires": {
         "https-proxy-agent": "^5.0.0",
         "mkdirp": "^0.5.5",
@@ -5359,18 +5350,6 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
-    "array.prototype.filter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.0.tgz",
-      "integrity": "sha512-TfO1gz+tLm+Bswq0FBOXPqAchtCr2Rn48T8dLJoRFl8NoEosjZmzptmuo1X8aZBzZcqsR1W8U761tjACJtngTQ==",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0",
-        "es-array-method-boxes-properly": "^1.0.0",
-        "is-string": "^1.0.5"
-      }
-    },
     "array.prototype.flat": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
@@ -5449,12 +5428,9 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "available-typed-arrays": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.3.tgz",
-      "integrity": "sha512-CuPhFULixV/d89POo1UG4GqGbR7dmrefY2ZdmsYakeR4gOSJXoF7tfeaiqMHGOMrlTiJoeEs87fpLsBYmE2BMw==",
-      "requires": {
-        "array.prototype.filter": "^1.0.0"
-      }
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.4.tgz",
+      "integrity": "sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA=="
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -5628,12 +5604,12 @@
       }
     },
     "babel-plugin-polyfill-corejs2": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.1.tgz",
-      "integrity": "sha512-hXGSPbr6IbjeMyGew+3uGIAkRjBFSOJ9FLDZNOfHuyJZCcoia4nd/72J0bSgvfytcVfUcP/dxEVcUhVJuQRtSw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.2.tgz",
+      "integrity": "sha512-kISrENsJ0z5dNPq5eRvcctITNHYXWOA4DUZRFYCz3jYCcvTb/A546LIddmoGNMVYg2U38OyFeNosQwI9ENTqIQ==",
       "requires": {
         "@babel/compat-data": "^7.13.11",
-        "@babel/helper-define-polyfill-provider": "^0.2.1",
+        "@babel/helper-define-polyfill-provider": "^0.2.2",
         "semver": "^6.1.1"
       },
       "dependencies": {
@@ -5645,20 +5621,20 @@
       }
     },
     "babel-plugin-polyfill-corejs3": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.1.tgz",
-      "integrity": "sha512-WZCqF3DLUhdTD/P381MDJfuP18hdCZ+iqJ+wHtzhWENpsiof284JJ1tMQg1CE+hfCWyG48F7e5gDMk2c3Laz7w==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.2.tgz",
+      "integrity": "sha512-l1Cf8PKk12eEk5QP/NQ6TH8A1pee6wWDJ96WjxrMXFLHLOBFzYM4moG80HFgduVhTqAFez4alnZKEhP/bYHg0A==",
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.2.1",
+        "@babel/helper-define-polyfill-provider": "^0.2.2",
         "core-js-compat": "^3.9.1"
       }
     },
     "babel-plugin-polyfill-regenerator": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.1.tgz",
-      "integrity": "sha512-T3bYyL3Sll2EtC94v3f+fA8M28q7YPTOZdB++SRHjvYZTvtd+WorMUq3tDTD4Q7Kjk1LG0gGromslKjcO5p2TA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.2.tgz",
+      "integrity": "sha512-Goy5ghsc21HgPDFtzRkSirpZVW35meGoTmTOb2bxqdl60ghub4xOidgNTHaZfQ2FaxQsKmwvXtOAkcIS4SMBWg==",
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.2.1"
+        "@babel/helper-define-polyfill-provider": "^0.2.2"
       }
     },
     "babel-plugin-react-native-web": {
@@ -6034,9 +6010,9 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001228",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A=="
+      "version": "1.0.30001230",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz",
+      "integrity": "sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -6390,9 +6366,9 @@
       "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
     },
     "core-js-compat": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.12.1.tgz",
-      "integrity": "sha512-i6h5qODpw6EsHAoIdQhKoZdWn+dGBF3dSS8m5tif36RlWvW3A6+yu2S16QHUo3CrkzrnEskMAt9f8FxmY9fhWQ==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.13.0.tgz",
+      "integrity": "sha512-jhbI2zpVskgfDC9mGRaDo1gagd0E0i/kYW0+WvibL/rafEHKAHO653hEXIxJHqRlRLITluXtRH3AGTL5qJmifQ==",
       "requires": {
         "browserslist": "^4.16.6",
         "semver": "7.0.0"
@@ -6503,9 +6479,9 @@
       }
     },
     "dayjs": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
-      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw=="
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.5.tgz",
+      "integrity": "sha512-BUFis41ikLz+65iH6LHQCDm4YPMj5r1YFLdupPIyM4SGcXMmtiLQ7U37i+hGS8urIuqe7I/ou3IS1jVc4nbN4g=="
     },
     "debug": {
       "version": "4.3.1",
@@ -6724,9 +6700,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.738",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.738.tgz",
-      "integrity": "sha512-vCMf4gDOpEylPSLPLSwAEsz+R3ShP02Y3cAKMZvTqule3XcPp7tgc/0ESI7IS6ZeyBlGClE50N53fIOkcIVnpw=="
+      "version": "1.3.740",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.740.tgz",
+      "integrity": "sha512-Mi2m55JrX2BFbNZGKYR+2ItcGnR4O5HhrvgoRRyZQlaMGQULqDhoGkLWHzJoshSzi7k1PUofxcDbNhlFrDZNhg=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -6809,9 +6785,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-      "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.2.tgz",
+      "integrity": "sha512-byRiNIQXE6HWNySaU6JohoNXzYgbBjztwFnBLUTiJmWXjaU9bSq3urQLUlNLQ292tc+gc07zYZXNZjaOoAX3sw==",
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -6821,20 +6797,15 @@
         "has-symbols": "^1.0.2",
         "is-callable": "^1.2.3",
         "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.2",
-        "is-string": "^1.0.5",
-        "object-inspect": "^1.9.0",
+        "is-regex": "^1.1.3",
+        "is-string": "^1.0.6",
+        "object-inspect": "^1.10.3",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.2",
         "string.prototype.trimend": "^1.0.4",
         "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.0"
+        "unbox-primitive": "^1.0.1"
       }
-    },
-    "es-array-method-boxes-properly": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
     },
     "es-get-iterator": {
       "version": "1.1.2",
@@ -7012,9 +6983,9 @@
           }
         },
         "globals": {
-          "version": "13.8.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.8.0.tgz",
-          "integrity": "sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==",
+          "version": "13.9.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
+          "integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -7743,14 +7714,80 @@
       "requires": {
         "@expo/config": "^3.3.35",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "@expo/config": {
+          "version": "3.3.43",
+          "resolved": "https://registry.npmjs.org/@expo/config/-/config-3.3.43.tgz",
+          "integrity": "sha512-5a78fQqTKk7RhgrW5XzHS8ylCo9YRjZrheLyVDNNfvwAD8YjeBz6bFWsItZPpAIoaDgkLh0a8uhc11DCmqoKpw==",
+          "requires": {
+            "@babel/core": "7.9.0",
+            "@babel/plugin-proposal-class-properties": "~7.12.13",
+            "@babel/preset-env": "~7.12.13",
+            "@babel/preset-typescript": "~7.12.13",
+            "@expo/config-plugins": "1.0.33",
+            "@expo/config-types": "^40.0.0-beta.2",
+            "@expo/json-file": "8.2.30",
+            "fs-extra": "9.0.0",
+            "getenv": "^1.0.0",
+            "glob": "7.1.6",
+            "require-from-string": "^2.0.2",
+            "resolve-from": "^5.0.0",
+            "semver": "7.3.2",
+            "slugify": "^1.3.4"
+          }
+        },
+        "@expo/config-plugins": {
+          "version": "1.0.33",
+          "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-1.0.33.tgz",
+          "integrity": "sha512-YQJop0c69LKD/6ZJJto7klS7TDmzgs44TI0Z5RBqesOjYlDwNFcQk2Rl2BaA1wlAYkH+rRrhN2+WjjSyD9HiPg==",
+          "requires": {
+            "@expo/config-types": "^40.0.0-beta.2",
+            "@expo/configure-splash-screen": "0.4.0",
+            "@expo/image-utils": "0.3.14",
+            "@expo/json-file": "8.2.30",
+            "@expo/plist": "0.0.13",
+            "find-up": "~5.0.0",
+            "fs-extra": "9.0.0",
+            "getenv": "^1.0.0",
+            "glob": "7.1.6",
+            "resolve-from": "^5.0.0",
+            "slash": "^3.0.0",
+            "xcode": "^3.0.1",
+            "xml2js": "^0.4.23"
+          }
+        }
       }
     },
     "expo-device": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/expo-device/-/expo-device-3.2.0.tgz",
-      "integrity": "sha512-MPtyut6bMlT8Gu3AH5VsXeF2DiulcnG3Q9q1LosruCBDdcTcDpXDXMaN0ZgTjWKOVgoMVkkR5e5WxZcS9Qlj9g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/expo-device/-/expo-device-2.4.0.tgz",
+      "integrity": "sha512-mxBiX6nvvtbKot3Kmmb2y8lo4Ki8jWGdUnpC2OX70Yiy75c8mOVbHUe2VMEnx3SysXycwvC5KzJSDy+PuDqovg==",
       "requires": {
+        "fbjs": "1.0.0",
         "ua-parser-js": "^0.7.19"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+        },
+        "fbjs": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+          "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+          "requires": {
+            "core-js": "^2.4.1",
+            "fbjs-css-vars": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        }
       }
     },
     "expo-error-recovery": {
@@ -7765,6 +7802,28 @@
       "requires": {
         "@expo/config-plugins": "^1.0.18",
         "uuid": "^3.4.0"
+      },
+      "dependencies": {
+        "@expo/config-plugins": {
+          "version": "1.0.33",
+          "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-1.0.33.tgz",
+          "integrity": "sha512-YQJop0c69LKD/6ZJJto7klS7TDmzgs44TI0Z5RBqesOjYlDwNFcQk2Rl2BaA1wlAYkH+rRrhN2+WjjSyD9HiPg==",
+          "requires": {
+            "@expo/config-types": "^40.0.0-beta.2",
+            "@expo/configure-splash-screen": "0.4.0",
+            "@expo/image-utils": "0.3.14",
+            "@expo/json-file": "8.2.30",
+            "@expo/plist": "0.0.13",
+            "find-up": "~5.0.0",
+            "fs-extra": "9.0.0",
+            "getenv": "^1.0.0",
+            "glob": "7.1.6",
+            "resolve-from": "^5.0.0",
+            "slash": "^3.0.0",
+            "xcode": "^3.0.1",
+            "xml2js": "^0.4.23"
+          }
+        }
       }
     },
     "expo-firebase-analytics": {
@@ -7819,9 +7878,9 @@
           }
         },
         "core-js": {
-          "version": "3.12.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.12.1.tgz",
-          "integrity": "sha512-Ne9DKPHTObRuB09Dru5AjwKjY4cJHVGu+y5f7coGn1E9Grkc3p2iBwE9AI/nJzsE29mQF7oq+mhYYRqOMFN1Bw=="
+          "version": "3.13.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.13.0.tgz",
+          "integrity": "sha512-iWDbiyha1M5vFwPFmQnvRv+tJzGbFAm6XimJUT0NgHYW3xZEs1SkCAcasWSVFxpI2Xb/V1DDJckq3v90+bQnog=="
         }
       }
     },
@@ -10422,6 +10481,49 @@
         "react-test-renderer": "~16.11.0"
       },
       "dependencies": {
+        "@expo/config": {
+          "version": "3.3.43",
+          "resolved": "https://registry.npmjs.org/@expo/config/-/config-3.3.43.tgz",
+          "integrity": "sha512-5a78fQqTKk7RhgrW5XzHS8ylCo9YRjZrheLyVDNNfvwAD8YjeBz6bFWsItZPpAIoaDgkLh0a8uhc11DCmqoKpw==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "7.9.0",
+            "@babel/plugin-proposal-class-properties": "~7.12.13",
+            "@babel/preset-env": "~7.12.13",
+            "@babel/preset-typescript": "~7.12.13",
+            "@expo/config-plugins": "1.0.33",
+            "@expo/config-types": "^40.0.0-beta.2",
+            "@expo/json-file": "8.2.30",
+            "fs-extra": "9.0.0",
+            "getenv": "^1.0.0",
+            "glob": "7.1.6",
+            "require-from-string": "^2.0.2",
+            "resolve-from": "^5.0.0",
+            "semver": "7.3.2",
+            "slugify": "^1.3.4"
+          }
+        },
+        "@expo/config-plugins": {
+          "version": "1.0.33",
+          "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-1.0.33.tgz",
+          "integrity": "sha512-YQJop0c69LKD/6ZJJto7klS7TDmzgs44TI0Z5RBqesOjYlDwNFcQk2Rl2BaA1wlAYkH+rRrhN2+WjjSyD9HiPg==",
+          "dev": true,
+          "requires": {
+            "@expo/config-types": "^40.0.0-beta.2",
+            "@expo/configure-splash-screen": "0.4.0",
+            "@expo/image-utils": "0.3.14",
+            "@expo/json-file": "8.2.30",
+            "@expo/plist": "0.0.13",
+            "find-up": "~5.0.0",
+            "fs-extra": "9.0.0",
+            "getenv": "^1.0.0",
+            "glob": "7.1.6",
+            "resolve-from": "^5.0.0",
+            "slash": "^3.0.0",
+            "xcode": "^3.0.1",
+            "xml2js": "^0.4.23"
+          }
+        },
         "@jest/console": {
           "version": "25.5.0",
           "resolved": "https://registry.npmjs.org/@jest/console/-/console-25.5.0.tgz",
@@ -10624,6 +10726,14 @@
           "dev": true,
           "requires": {
             "semver": "^6.0.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
           }
         },
         "micromatch": {
@@ -10669,12 +10779,6 @@
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1"
           }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
@@ -13077,9 +13181,9 @@
       },
       "dependencies": {
         "ws": {
-          "version": "7.4.5",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-          "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
+          "version": "7.4.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
           "dev": true
         }
       }
@@ -14489,15 +14593,14 @@
       }
     },
     "object.entries": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.3.tgz",
-      "integrity": "sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.4.tgz",
+      "integrity": "sha512-h4LWKWE+wKQGhtMjZEBud7uLGhqyLwj8fpHOarZhD2uY3C9cRtk57VQ89ke3moByLXMedqs3XCHzyb4AmA2DjA==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1",
-        "has": "^1.0.3"
+        "es-abstract": "^1.18.2"
       }
     },
     "object.fromentries": {
@@ -14521,15 +14624,14 @@
       }
     },
     "object.values": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
-      "integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
+      "integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.2",
-        "has": "^1.0.3"
+        "es-abstract": "^1.18.2"
       }
     },
     "omggif": {
@@ -14961,6 +15063,13 @@
         "base64-js": "^1.5.1",
         "xmlbuilder": "^9.0.7",
         "xmldom": "^0.5.0"
+      },
+      "dependencies": {
+        "xmlbuilder": {
+          "version": "9.0.7",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+        }
       }
     },
     "plugin-error": {
@@ -15220,18 +15329,18 @@
       }
     },
     "react-devtools-core": {
-      "version": "4.13.4",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.13.4.tgz",
-      "integrity": "sha512-su/lI4LdiK5P1YgZpbm8K1iNQX6s0Lq5fJLa1ZcnpewvrqP5V14svHrbPmrU5ptMUSiwjZ3/CBmc/JCZOuuiHQ==",
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.13.5.tgz",
+      "integrity": "sha512-k+P5VSKM6P22Go9IQ8dJmjj9fbztvKt1iRDI/4wS5oTvd1EnytIJMYB59wZt+D3kgp64jklNX/MRmY42xAQ08g==",
       "requires": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
       },
       "dependencies": {
         "ws": {
-          "version": "7.4.5",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-          "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g=="
+          "version": "7.4.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
         }
       }
     },
@@ -16149,9 +16258,9 @@
       }
     },
     "sentry-expo": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/sentry-expo/-/sentry-expo-3.1.4.tgz",
-      "integrity": "sha512-BQFpXnGXLo6SacuwHGDs8UvRKqov0hkTHqp3BmX+w87J7/HH8OchmzOsbrNu6arO0+SLppbaXLjlMd3yWin1Qg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/sentry-expo/-/sentry-expo-3.1.3.tgz",
+      "integrity": "sha512-f4sjfJeIH9dXJAW5xOKcazbAN3HKB2DnLk6Hrlaf47/2pinKwEObOWSqrJVVPRw9LGAKS4lrZtTVwYFbkeXXlw==",
       "requires": {
         "@expo/config-plugins": "~1.0.13",
         "@expo/config-types": "^40.0.0-beta.2",
@@ -16160,14 +16269,90 @@
         "@sentry/integrations": "^6.2.0",
         "@sentry/react-native": "^2.2.1",
         "@sentry/types": "^6.2.0",
-        "expo-application": "~3.1.2",
-        "expo-constants": "~10.1.3",
-        "expo-device": "~3.2.0",
+        "expo-application": "^2.2.1",
+        "expo-constants": "^9.3.5",
+        "expo-device": "^2.4.0",
         "expo-updates": "~0.3.5",
         "mkdirp": "^1.0.3",
         "rimraf": "^2.6.1"
       },
       "dependencies": {
+        "@expo/config": {
+          "version": "3.3.43",
+          "resolved": "https://registry.npmjs.org/@expo/config/-/config-3.3.43.tgz",
+          "integrity": "sha512-5a78fQqTKk7RhgrW5XzHS8ylCo9YRjZrheLyVDNNfvwAD8YjeBz6bFWsItZPpAIoaDgkLh0a8uhc11DCmqoKpw==",
+          "requires": {
+            "@babel/core": "7.9.0",
+            "@babel/plugin-proposal-class-properties": "~7.12.13",
+            "@babel/preset-env": "~7.12.13",
+            "@babel/preset-typescript": "~7.12.13",
+            "@expo/config-plugins": "1.0.33",
+            "@expo/config-types": "^40.0.0-beta.2",
+            "@expo/json-file": "8.2.30",
+            "fs-extra": "9.0.0",
+            "getenv": "^1.0.0",
+            "glob": "7.1.6",
+            "require-from-string": "^2.0.2",
+            "resolve-from": "^5.0.0",
+            "semver": "7.3.2",
+            "slugify": "^1.3.4"
+          }
+        },
+        "@expo/config-plugins": {
+          "version": "1.0.33",
+          "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-1.0.33.tgz",
+          "integrity": "sha512-YQJop0c69LKD/6ZJJto7klS7TDmzgs44TI0Z5RBqesOjYlDwNFcQk2Rl2BaA1wlAYkH+rRrhN2+WjjSyD9HiPg==",
+          "requires": {
+            "@expo/config-types": "^40.0.0-beta.2",
+            "@expo/configure-splash-screen": "0.4.0",
+            "@expo/image-utils": "0.3.14",
+            "@expo/json-file": "8.2.30",
+            "@expo/plist": "0.0.13",
+            "find-up": "~5.0.0",
+            "fs-extra": "9.0.0",
+            "getenv": "^1.0.0",
+            "glob": "7.1.6",
+            "resolve-from": "^5.0.0",
+            "slash": "^3.0.0",
+            "xcode": "^3.0.1",
+            "xml2js": "^0.4.23"
+          }
+        },
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+        },
+        "expo-application": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-2.4.1.tgz",
+          "integrity": "sha512-VHDvXz55LIYdLoE1aR0AFycB1jz4ggbMToUbKAbCEjro+PdUNm/Gj8gQeFgH6wL2oAztQH4qJ+uiOwrw8SFK+Q=="
+        },
+        "expo-constants": {
+          "version": "9.3.5",
+          "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-9.3.5.tgz",
+          "integrity": "sha512-qIlv2ffSjQl3wrvJwXYoNfQNfH/sK46EXcgyEQnQ1SAQO4ukwTEpG9j3fdW6aTiVEVrv/DsA1IaVRqKrUwSd3A==",
+          "requires": {
+            "@expo/config": "^3.3.18",
+            "fbjs": "1.0.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "fbjs": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+          "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+          "requires": {
+            "core-js": "^2.4.1",
+            "fbjs-css-vars": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        },
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -16300,17 +16485,17 @@
       }
     },
     "sinon": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.0.0.tgz",
-      "integrity": "sha512-iLdNOhEDVHf1GJwWIqiFQe7QqYsqKDSYUUmmb180WCu3l0Cz+CKBxsiSa8P5fTJvTp1lwE77uK/aHzUuJKr1cA==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.1.tgz",
+      "integrity": "sha512-ZSSmlkSyhUWbkF01Z9tEbxZLF/5tRC9eojCdFh33gtQaP7ITQVaMWQHGuFM7Cuf/KEfihuh1tTl3/ABju3AQMg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.3",
         "@sinonjs/fake-timers": "^7.1.0",
         "@sinonjs/samsam": "^6.0.2",
         "diff": "^5.0.0",
-        "nise": "^5.0.4",
-        "supports-color": "^8.1.1"
+        "nise": "^5.1.0",
+        "supports-color": "^7.2.0"
       },
       "dependencies": {
         "has-flag": {
@@ -16320,9 +16505,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -16682,15 +16867,16 @@
       }
     },
     "string.prototype.matchall": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.4.tgz",
-      "integrity": "sha512-pknFIWVachNcyqRfaQSeu/FUfpvJTe4uskUSZ9Wc1RijsPuzbZ8TyYT8WCNnntCjUEqQ3vUHMAfVj2+wLAisPQ==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.5.tgz",
+      "integrity": "sha512-Z5ZaXO0svs0M2xd/6By3qpeKpLKd9mO4v4q3oMEQrk8Ck4xOD5d5XeBOOjGrmVZZ/AHB1S0CgG4N5r1G9N3E2Q==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.2",
-        "has-symbols": "^1.0.1",
+        "es-abstract": "^1.18.2",
+        "get-intrinsic": "^1.1.1",
+        "has-symbols": "^1.0.2",
         "internal-slot": "^1.0.3",
         "regexp.prototype.flags": "^1.3.1",
         "side-channel": "^1.0.4"
@@ -17745,9 +17931,9 @@
       }
     },
     "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-14.0.0.tgz",
+      "integrity": "sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg=="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15641,44 +15641,16 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
       "integrity": "sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA=="
     },
-    "react-shallow-renderer": {
-      "version": "16.14.1",
-      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
-      "integrity": "sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==",
-      "dev": true,
-      "requires": {
-        "object-assign": "^4.1.1",
-        "react-is": "^16.12.0 || ^17.0.0"
-      }
-    },
     "react-test-renderer": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
-      "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
+      "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
-        "react-is": "^17.0.2",
-        "react-shallow-renderer": "^16.13.1",
-        "scheduler": "^0.20.2"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-          "dev": true
-        },
-        "scheduler": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-          "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
+        "prop-types": "^15.6.2",
+        "react-is": "^16.8.6",
+        "scheduler": "^0.19.1"
       }
     },
     "read-env": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1223,15 +1223,15 @@
       }
     },
     "@expo/config": {
-      "version": "3.3.42",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-3.3.42.tgz",
-      "integrity": "sha512-BLFp9JvMHkBFutwKM+o9RhvmdllSyQpswvY9974Y8gjYsO5/BXfvT5J0GyUt1bdtqGyA8dlfo5jew/mtkeStRA==",
+      "version": "3.3.43",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-3.3.43.tgz",
+      "integrity": "sha512-5a78fQqTKk7RhgrW5XzHS8ylCo9YRjZrheLyVDNNfvwAD8YjeBz6bFWsItZPpAIoaDgkLh0a8uhc11DCmqoKpw==",
       "requires": {
         "@babel/core": "7.9.0",
         "@babel/plugin-proposal-class-properties": "~7.12.13",
         "@babel/preset-env": "~7.12.13",
         "@babel/preset-typescript": "~7.12.13",
-        "@expo/config-plugins": "1.0.32",
+        "@expo/config-plugins": "1.0.33",
         "@expo/config-types": "^40.0.0-beta.2",
         "@expo/json-file": "8.2.30",
         "fs-extra": "9.0.0",
@@ -1244,9 +1244,9 @@
       }
     },
     "@expo/config-plugins": {
-      "version": "1.0.32",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-1.0.32.tgz",
-      "integrity": "sha512-goQoBvWYq1fk/jdDYYioN5gYlEhmPVRP6Y9jxmCLTHoHhZHSI+Pl5BXidUqVNdE2XFhoiz9yLbjQrGgYFPXuwQ==",
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-1.0.33.tgz",
+      "integrity": "sha512-YQJop0c69LKD/6ZJJto7klS7TDmzgs44TI0Z5RBqesOjYlDwNFcQk2Rl2BaA1wlAYkH+rRrhN2+WjjSyD9HiPg==",
       "requires": {
         "@expo/config-types": "^40.0.0-beta.2",
         "@expo/configure-splash-screen": "0.4.0",
@@ -1259,7 +1259,6 @@
         "glob": "7.1.6",
         "resolve-from": "^5.0.0",
         "slash": "^3.0.0",
-        "slugify": "^1.3.4",
         "xcode": "^3.0.1",
         "xml2js": "^0.4.23"
       }
@@ -1332,11 +1331,11 @@
       }
     },
     "@expo/metro-config": {
-      "version": "0.1.68",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.1.68.tgz",
-      "integrity": "sha512-jxcGOCPUK9SiHqX9LB0c7N9LbasDIUYghqC6xc0VUS+8ZmbDZZ/QFjeKUJbHjjXsZG+jSGcft37PdUf4Mrcbzg==",
+      "version": "0.1.69",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.1.69.tgz",
+      "integrity": "sha512-Py1Zovxl5Esy09xewnOytOPgt5xC+QWP7bgvF4VML6EE05e7Qrz3VnLZJxJA8H0hGJc6/ctwO5tttctZpf1qwQ==",
       "requires": {
-        "@expo/config": "3.3.42",
+        "@expo/config": "3.3.43",
         "chalk": "^4.1.0",
         "getenv": "^1.0.0",
         "metro-react-native-babel-transformer": "^0.59.0"
@@ -15642,16 +15641,44 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",
       "integrity": "sha512-Hwln1VNuGl/6bVwnd0Xdn1e84gT/8T9aYNL+HAKDArLCS7LWjwr7StE30IEYbIkx0Vi3vs+coQxe+SQDbGbbpA=="
     },
-    "react-test-renderer": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
-      "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
+    "react-shallow-renderer": {
+      "version": "16.14.1",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
+      "integrity": "sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.8.6",
-        "scheduler": "^0.19.1"
+        "react-is": "^16.12.0 || ^17.0.0"
+      }
+    },
+    "react-test-renderer": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
+      "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^17.0.2",
+        "react-shallow-renderer": "^16.13.1",
+        "scheduler": "^0.20.2"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
+        },
+        "scheduler": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+          "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "read-env": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4808,18 +4808,18 @@
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
-      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.0.tgz",
+      "integrity": "sha512-hAEzXi6Wbvlb67NnGMGSNOeAflLVnMa4yliPU/ty1qjgW/vAletH15/v/esJwASSIA0YlIyjnloenFbEZc9q9A==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
       }
     },
     "@sinonjs/samsam": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
-      "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.0.2.tgz",
+      "integrity": "sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.6.0",
@@ -6659,9 +6659,9 @@
       "dev": true
     },
     "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true
     },
     "diff-sequences": {
@@ -14291,13 +14291,13 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "nise": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-4.1.0.tgz",
-      "integrity": "sha512-eQMEmGN/8arp0xsvGoQ+B1qvSkR73B1nWSCh7nOt5neMCtwcQVYQGdzQMhcNscktTsWB54xnlSQFzOAPJD8nXA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
+      "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0",
-        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/fake-timers": "^7.0.4",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
@@ -16386,17 +16386,17 @@
       }
     },
     "sinon": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-10.0.0.tgz",
-      "integrity": "sha512-XAn5DxtGVJBlBWYrcYKEhWCz7FLwZGdyvANRyK06419hyEpdT0dMc5A8Vcxg5SCGHc40CsqoKsc1bt1CbJPfNw==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.0.0.tgz",
+      "integrity": "sha512-iLdNOhEDVHf1GJwWIqiFQe7QqYsqKDSYUUmmb180WCu3l0Cz+CKBxsiSa8P5fTJvTp1lwE77uK/aHzUuJKr1cA==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.8.1",
-        "@sinonjs/fake-timers": "^6.0.1",
-        "@sinonjs/samsam": "^5.3.1",
-        "diff": "^4.0.2",
-        "nise": "^4.1.0",
-        "supports-color": "^7.1.0"
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^7.1.0",
+        "@sinonjs/samsam": "^6.0.2",
+        "diff": "^5.0.0",
+        "nise": "^5.0.4",
+        "supports-color": "^8.1.1"
       },
       "dependencies": {
         "has-flag": {
@@ -16406,9 +16406,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "firebase": "8.2.3",
     "jest-expo": "^41.0.0",
-    "react-test-renderer": "^16.14.0",
+    "react-test-renderer": "^17.0.2",
     "sinon": "^10.0.0",
     "typescript": "~4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "firebase": "8.2.3",
     "jest-expo": "^41.0.0",
     "react-test-renderer": "^17.0.2",
-    "sinon": "^10.0.0",
+    "sinon": "^11.0.0",
     "typescript": "~4.0.0"
   },
   "private": true

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "firebase": "8.2.3",
     "jest-expo": "^41.0.0",
-    "react-test-renderer": "^17.0.2",
+    "react-test-renderer": "^16.14.0",
     "sinon": "^11.0.0",
     "typescript": "~4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-native-gesture-handler": "~1.10.2",
     "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "~3.0.0",
-    "sentry-expo": "^3.1.0"
+    "sentry-expo": "^3.1.4"
   },
   "devDependencies": {
     "@babel/core": "~7.9.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-native-gesture-handler": "~1.10.2",
     "react-native-safe-area-context": "3.2.0",
     "react-native-screens": "~3.0.0",
-    "sentry-expo": "^3.1.4"
+    "sentry-expo": "^3.1.0"
   },
   "devDependencies": {
     "@babel/core": "~7.9.0",


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- [x] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui 
  - Non parce que

Mise a jour du paquet : 

- sinon: ^10.0.0 -> ^11.0.0: fixe bugs + avertissement lors de potentielles fuites de mémoire: https://github.com/sinonjs/sinon/blob/master/docs/changelog.md

⚠️ 2 vulnérabilités sont liées a `node-fetch` qui est une dépendance de `sentry-expo`. Pour l'instant elles ne sont pas fixées par la dernière version de `sentry-expo` (version 3.1.3), nous avons donc laissé le paquet a la version voulue par expo (version 3.1.0). Point d'attention sur ce paquet pour les prochaines maj. 