### PR TITLE
COM-2103 add useFocusEffect to refresh events when timeStampingScreen…

### DIFF
--- a/src/screens/timeStamping/TimeStampingProfile/index.tsx
+++ b/src/screens/timeStamping/TimeStampingProfile/index.tsx
@@ -19,13 +19,14 @@ const renderEvent = (event: EventType) => (
 );
 
 const TimeStampingProfile = () => {
-  const [displayedDate, setdisplayedDate] = useState<Date>(new Date());
+  const [displayedDate, setDisplayedDate] = useState<Date>(new Date());
   const [events, setEvents] = useState<EventType[]>([]);
   const isActive = useRef<boolean>(true);
   const { loggedUser } = useContext(AuthContext);
 
   useEffect(() => {
-    const interval = setInterval(() => { setdisplayedDate(new Date()); }, 60000);
+    const interval = setInterval(() => { setDisplayedDate(new Date()); }, 60000);
+
     return () => clearInterval(interval);
   }, []);
 
@@ -49,10 +50,10 @@ const TimeStampingProfile = () => {
           console.error(e);
         }
       };
+
       fetchInterventions();
-      return () => {
-        isActive.current = false;
-      };
+
+      return () => { isActive.current = false; };
     }, [loggedUser, isActive])
   );
 

--- a/src/screens/timeStamping/TimeStampingProfile/index.tsx
+++ b/src/screens/timeStamping/TimeStampingProfile/index.tsx
@@ -1,5 +1,6 @@
-import React, { useContext, useEffect, useState, useCallback } from 'react';
+import React, { useContext, useEffect, useState, useCallback, useRef } from 'react';
 import { Text, View, ScrollView } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
 import commonStyle from '../../../styles/common';
 import Events from '../../../api/Events';
 import { Context as AuthContext } from '../../../context/AuthContext';
@@ -18,44 +19,50 @@ const renderEvent = (event: EventType) => (
 );
 
 const TimeStampingProfile = () => {
-  const [currentDate, setCurrentDate] = useState<Date>(new Date());
+  const [displayedDate, setdisplayedDate] = useState<Date>(new Date());
   const [events, setEvents] = useState<EventType[]>([]);
-
+  const isActive = useRef<boolean>(true);
   const { loggedUser } = useContext(AuthContext);
 
   useEffect(() => {
-    const interval = setInterval(() => { setCurrentDate(new Date()); }, 60000);
+    const interval = setInterval(() => { setdisplayedDate(new Date()); }, 60000);
     return () => clearInterval(interval);
   }, []);
 
-  const fetchInterventions = useCallback(async () => {
-    try {
-      if (!loggedUser || !loggedUser._id) return;
-      const params = {
-        auxiliary: loggedUser._id,
-        startDate: new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate(), 0, 0, 0, 0),
-        endDate: new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate(), 23, 59, 59, 999),
-        type: INTERVENTION,
+  useFocusEffect(
+    useCallback(() => {
+      isActive.current = true;
+      const fetchInterventions = async () => {
+        const today = new Date();
+        try {
+          if (!loggedUser || !loggedUser._id) return;
+          const params = {
+            auxiliary: loggedUser._id,
+            startDate: new Date(today.getFullYear(), today.getMonth(), today.getDate(), 0, 0, 0, 0),
+            endDate: new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23, 59, 59, 999),
+            type: INTERVENTION,
+          };
+          const fetchedEvents = await Events.events(params);
+
+          if (isActive) setEvents(fetchedEvents);
+        } catch (e) {
+          console.error(e);
+        }
       };
-      const fetchedEvents = await Events.events(params);
-
-      setEvents(fetchedEvents);
-    } catch (e) {
-      console.error(e);
-    }
-  }, [loggedUser, currentDate]);
-
-  useEffect(() => {
-    if (loggedUser?._id) fetchInterventions();
-  }, [loggedUser, fetchInterventions]);
+      fetchInterventions();
+      return () => {
+        isActive.current = false;
+      };
+    }, [loggedUser, isActive])
+  );
 
   return (
     <ScrollView style={styles.screen} testID="TimeStampingProfile">
       <Text style={commonStyle.title}>Horodatage</Text>
       <View style={styles.container}>
         <View>
-          <Text style={styles.date}>{capitalizeFirstLetter(formatDate(currentDate))}</Text>
-          <Text style={styles.time}>{formatTime(currentDate)}</Text>
+          <Text style={styles.date}>{capitalizeFirstLetter(formatDate(displayedDate))}</Text>
+          <Text style={styles.time}>{formatTime(displayedDate)}</Text>
         </View>
         <View style={styles.viewIntervention}>
           <Text style={styles.textIntervention}>{events.length} {formatWordToPlural(events, 'intervention')}</Text>

--- a/src/screens/timeStamping/TimeStampingProfile/index.tsx
+++ b/src/screens/timeStamping/TimeStampingProfile/index.tsx
@@ -25,9 +25,9 @@ const TimeStampingProfile = () => {
   const { loggedUser } = useContext(AuthContext);
 
   const handleBackground = useCallback((nextAppState: AppStateStatus) => {
-    if (nextAppState === ACTIVE_STATE && !isAppFocused) setIsAppFocused(true);
+    if (nextAppState === ACTIVE_STATE) setIsAppFocused(true);
     else setIsAppFocused(false);
-  }, [isAppFocused]);
+  }, []);
 
   useEffect(() => {
     const interval = setInterval(() => { setDisplayedDate(new Date()); }, 60000);

--- a/src/screens/timeStamping/TimeStampingProfile/index.tsx
+++ b/src/screens/timeStamping/TimeStampingProfile/index.tsx
@@ -36,13 +36,14 @@ const TimeStampingProfile = () => {
       let appState = AppState.currentState;
 
       const handleBackground = (nextAppState: AppStateStatus) => {
+        setIsAppBackgrounded(false);
         if ((appState === 'background' || appState === 'inactive') && nextAppState === ACTIVE_STATE) {
           setIsAppBackgrounded(true);
         }
         appState = nextAppState;
       };
 
-      handleBackground(ACTIVE_STATE);
+      AppState.addEventListener('change', handleBackground);
 
       const fetchInterventions = async () => {
         const today = new Date();
@@ -66,7 +67,7 @@ const TimeStampingProfile = () => {
 
       return () => {
         isActive = false;
-        setIsAppBackgrounded(false);
+        AppState.removeEventListener('change', handleBackground);
       };
     }, [loggedUser, isAppBackgrounded])
   );


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- [x] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui parce que
  - Non parce que

- [x] Je n'envoie pas de nouveau paramètre dans une route -np
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite:
- [ ] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas -np
- [ ] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas. -np
- [x] Je n'ai pas changé de constante

- J'ai ajouté une variable d'environnement :
  - [ ] Je l'ai ajouté dans env.dev et env.prod aussi

Cas d'usage: Les interventions sont mises a jour lorsque:
-l'auxiliaire horodate le début ou la fin d'une intervention et revient sur la page d'horodatage 
-l'auxiliaire navigue entre les pages profil et horodatage
-l'auxiliaire met l'application en arrière plan puis revient dessus 
