### PR TITLE
COM-2117

### DIFF
--- a/src/api/Events.ts
+++ b/src/api/Events.ts
@@ -5,7 +5,13 @@ import { EventTypeEnum } from '../types/EventType';
 export type timeStampEventPayloadType = { action: string, reason: string, startDate?: Date, endDate?: Date };
 
 export default {
-  events: async (params: { auxiliary: string, startDate: Date, endDate: Date, type: EventTypeEnum }) => {
+  list: async (params: {
+    auxiliary: string,
+    startDate: Date,
+    endDate: Date,
+    type: EventTypeEnum,
+    isCancelled: boolean
+  }) => {
     const { baseURL } = Environment.getEnvVars();
     const events = await axiosLogged.get(`${baseURL}/events`, { params });
     return events.data.data.events;

--- a/src/screens/timeStamping/TimeStampingProfile/index.tsx
+++ b/src/screens/timeStamping/TimeStampingProfile/index.tsx
@@ -52,8 +52,9 @@ const TimeStampingProfile = () => {
             startDate: new Date(today.getFullYear(), today.getMonth(), today.getDate(), 0, 0, 0, 0),
             endDate: new Date(today.getFullYear(), today.getMonth(), today.getDate(), 23, 59, 59, 999),
             type: INTERVENTION,
+            isCancelled: false,
           };
-          const fetchedEvents = await Events.events(params);
+          const fetchedEvents = await Events.list(params);
 
           if (isActive) setEvents(fetchedEvents);
         } catch (e) {


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- [x] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui parce que
  - Non parce que

- [ ] Je n'envoie pas de nouveau paramètre dans une route
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite:
- [ ] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas
- [ ] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas.
- [ ] Je n'ai pas changé de constante

- J'ai ajouté une variable d'environnement : -np
  - [ ] Je l'ai ajouté dans env.dev et env.prod aussi

- Cas d'usage : lorsque l'auxiliaire annule une intervention depuis le planning, celle-ci disparait de la page horodatage.
- Pour tester l'affichage des erreurs en front:
    - dans `TimeStampingProfile` passer `isCancelled: false` a `isCancelled: true` et essayer d'horodater une intervention qui est annulée
