### PR TITLE
COM-2237 redirect to staging url + fix removal of userid on logout

### DIFF
--- a/__tests__/authentication.test.js
+++ b/__tests__/authentication.test.js
@@ -17,22 +17,26 @@ describe('authentication', () => {
   let loggedAxiosMock;
   let notLoggedAxiosMock;
   let getEnvVarsStub;
+  let getBaseUrlStub;
 
   beforeEach(() => {
     loggedAxiosMock = new MockAdapter(loggedAxios);
     notLoggedAxiosMock = new MockAdapter(notLoggedAxios);
     getEnvVarsStub = sinon.stub(Environment, 'getEnvVars');
+    getBaseUrlStub = sinon.stub(Environment, 'getBaseUrl');
   });
 
   afterEach(() => {
     loggedAxiosMock.restore();
     notLoggedAxiosMock.restore();
     getEnvVarsStub.restore();
+    getBaseUrlStub.restore();
     cleanup();
   });
 
   test('should connect user if right credentials', async () => {
     getEnvVarsStub.returns({ baseURL: 'test' });
+    getBaseUrlStub.returns('test');
 
     notLoggedAxiosMock.onGet(`${baseURL}/version/should-update`, { params: { mobileVersion: '1.0.0', appName: 'erp' } })
       .reply(200, { data: { mustUpdate: false } })
@@ -79,6 +83,7 @@ describe('authentication', () => {
 
   test('should not connect user if wrong credentials', async () => {
     getEnvVarsStub.returns({ baseURL: 'test' });
+    getBaseUrlStub.returns('test');
 
     notLoggedAxiosMock.onGet(`${baseURL}/version/should-update`, { params: { mobileVersion: '1.0.0', appName: 'erp' } })
       .reply(200, { data: { mustUpdate: false } })

--- a/src/api/Authentication.ts
+++ b/src/api/Authentication.ts
@@ -3,26 +3,26 @@ import Environment from '../../environment';
 
 export default {
   authenticate: async (payload: { email: string, password: string }) => {
-    const { baseURL } = Environment.getEnvVars();
+    const baseURL = await Environment.getBaseUrl({ email: payload.email });
     const response = await axiosNotLogged.post(`${baseURL}/users/authenticate`, payload);
     return response.data.data;
   },
   logOut: async () => {
-    const { baseURL } = Environment.getEnvVars();
+    const baseURL = await Environment.getBaseUrl();
     await axiosNotLogged.post(`${baseURL}/users/logout`);
   },
   refreshToken: async (payload: { refreshToken: string | null }) => {
-    const { baseURL } = Environment.getEnvVars();
+    const baseURL = await Environment.getBaseUrl();
     const refreshToken = await axiosNotLogged.post(`${baseURL}/users/refreshToken`, payload);
     return refreshToken.data.data;
   },
   forgotPassword: async (payload: { email: string, origin: string, type: string }) => {
-    const { baseURL } = Environment.getEnvVars();
+    const baseURL = await Environment.getBaseUrl({ email: payload.email });
     const response = await axiosNotLogged.post(`${baseURL}/users/forgot-password`, payload);
     return response.data.data.mailInfo;
   },
   passwordToken: async (email: string, token: string) => {
-    const { baseURL } = Environment.getEnvVars();
+    const baseURL = await Environment.getBaseUrl({ email });
     const checkToken = await axiosNotLogged.get(`${baseURL}/users/passwordtoken/${token}`, { params: { email } });
     return checkToken.data.data;
   },

--- a/src/api/Events.ts
+++ b/src/api/Events.ts
@@ -12,12 +12,12 @@ export default {
     type: EventTypeEnum,
     isCancelled: boolean
   }) => {
-    const { baseURL } = Environment.getEnvVars();
+    const baseURL = await Environment.getBaseUrl();
     const events = await axiosLogged.get(`${baseURL}/events`, { params });
     return events.data.data.events;
   },
   timeStampEvent: async (id: string, data: timeStampEventPayloadType) => {
-    const { baseURL } = Environment.getEnvVars();
+    const baseURL = await Environment.getBaseUrl();
     await axiosLogged.put(`${baseURL}/events/${id}/timestamping`, data);
   },
 };

--- a/src/api/Users.ts
+++ b/src/api/Users.ts
@@ -10,26 +10,26 @@ type userInfos = {
 
 export default {
   exists: async (params: { email: string }) => {
-    const { baseURL } = Environment.getEnvVars();
+    const baseURL = await Environment.getBaseUrl({ email: params.email });
     const exists = await axiosNotLogged.get(`${baseURL}/users/exists`, { params });
 
     return exists.data.data.exists;
   },
   getById: async (id : string | null) => {
-    const { baseURL } = Environment.getEnvVars();
+    const baseURL = await Environment.getBaseUrl();
     const user = await axiosLogged.get(`${baseURL}/users/${id}`);
 
     return user.data.data.user;
   },
   updatePassword: async (userId: string, data: object, token = '') => {
-    const { baseURL } = Environment.getEnvVars();
+    const baseURL = await Environment.getBaseUrl({ userId });
     if (!token) await axiosLogged.put(`${baseURL}/users/${userId}/password`, data);
     else {
       await axiosNotLogged.put(`${baseURL}/users/${userId}/password`, data, { headers: { 'x-access-token': token } });
     }
   },
   setUser: async (userId: string | null, data: userInfos) => {
-    const { baseURL } = Environment.getEnvVars();
+    const baseURL = await Environment.getBaseUrl();
     await axiosLogged.put(`${baseURL}/users/${userId}`, data);
   },
 };

--- a/src/context/AuthContext.ts
+++ b/src/context/AuthContext.ts
@@ -42,6 +42,7 @@ const signOut = (dispatch: React.Dispatch<ActionType>) => async () => {
   await Authentication.logOut();
   await asyncStorage.removeCompaniToken();
   await asyncStorage.removeRefreshToken();
+  await asyncStorage.removeUserId();
 
   dispatch({ type: 'signOut' });
 };

--- a/src/core/helpers/asyncStorage.ts
+++ b/src/core/helpers/asyncStorage.ts
@@ -50,6 +50,8 @@ const setUserId = async (id: string): Promise<void> => AsyncStorage.setItem('use
 
 const getUserId = async (): Promise<string|null> => AsyncStorage.getItem('userId');
 
+const removeUserId = async (): Promise<void> => AsyncStorage.removeItem('userId');
+
 export default {
   isTokenValid,
   setCompaniToken,
@@ -60,4 +62,5 @@ export default {
   removeRefreshToken,
   setUserId,
   getUserId,
+  removeUserId,
 };


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- [x] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui parce que n'a pas d'incidence sur l'api
  - Non parce que

- [x] Je n'envoie pas de nouveau paramètre dans une route
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite:
- [ ] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas -np
- [ ] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas. -np
- [x] Je n'ai pas changé de constante

- J'ai ajouté une variable d'environnement : 
  - [x] Je l'ai ajouté dans env.dev et env.prod aussi
 
- Cas d'usage : Si je me connecte en tant qu'apple, je suis redirigé vers baseURLStaging 
- Avec une auxiliaire uniquement présente en dev
    - Vérifier que les appels sont bien redirigé sur dev
- Avec une auxiliaire uniquement présente en local 
    - Verifier que les appels sont bien redirigé en local 

Les routes a tester : 
- Se connecter 
- Se déconnecter
- Mot de passe oublié : 
    - Le mail est reconnu 
    - On peut s’envoyer un mail de récupération de mdp 
    - On peut envoyer le code de récupération 
    - On peut mettre a jour le mdr 
- Les informations de l’utilisateur s’affichent bien sur la page Profil
- Je peux mettre a jour les informations de mon utilisateur sur la page profil
- Je vois les événements sur la page horodatage
- Je peux horodater un événement 
- Refresh token : 
    - Remplacer dans AuthContext `await asyncStorage.setCompaniToken(token, (new Date()).toISOString());`
    - Fermer et rouvrir l’app