### PR TITLE
COM-2247 requests access to the camera when user starts timeStamp

### DIFF
--- a/src/components/TimeStampingCell/index.tsx
+++ b/src/components/TimeStampingCell/index.tsx
@@ -73,7 +73,6 @@ interface TimeStampingProps {
 
 const TimeStampingCell = ({ event }: TimeStampingProps) => {
   const [state, dispatch] = useReducer(reducer, initialState);
-  const [hasPermission, setHasPermission] = useState<boolean>(false);
   const [modalVisible, setModalVisible] = useState<boolean>(false);
 
   const navigation = useNavigation();
@@ -100,7 +99,7 @@ const TimeStampingCell = ({ event }: TimeStampingProps) => {
     { event: { _id: event._id, customer: { _id: event.customer._id, identity: event.customer.identity } }, eventStart }
   );
 
-  const requestPermission = async () => {
+  const requestPermission = async (eventStart:boolean) => {
     let { status } = await Camera.getPermissionsAsync();
 
     if (status !== GRANTED) {
@@ -108,8 +107,9 @@ const TimeStampingCell = ({ event }: TimeStampingProps) => {
       status = newStatus;
     }
 
+    if (status === GRANTED) goToBarCodeScanner(eventStart);
+
     setModalVisible(status !== GRANTED);
-    setHasPermission(status === GRANTED);
   };
 
   const askPermissionAgain = async () => {
@@ -125,12 +125,6 @@ const TimeStampingCell = ({ event }: TimeStampingProps) => {
     }
 
     setModalVisible(permission.status !== GRANTED);
-    setHasPermission(permission.status === GRANTED);
-  };
-
-  const startTimeStamping = async (eventStart: boolean) => {
-    await requestPermission();
-    if (hasPermission) goToBarCodeScanner(eventStart);
   };
 
   return (
@@ -148,7 +142,7 @@ const TimeStampingCell = ({ event }: TimeStampingProps) => {
           ? renderTimeStamp()
           : <>
             {!state.endHourStamped &&
-              <NiPrimaryButton title='Commencer' style={styles.button} onPress={() => startTimeStamping(true)} />}
+              <NiPrimaryButton title='Commencer' style={styles.button} onPress={() => requestPermission(true)} />}
           </>}
       </View>
       <View style={styles.sectionDelimiter} />
@@ -161,9 +155,9 @@ const TimeStampingCell = ({ event }: TimeStampingProps) => {
           ? renderTimeStamp()
           : <>
             {!state.startHourStamped &&
-              <NiSecondaryButton title='Terminer' onPress={() => startTimeStamping(false)} style={styles.button} />}
+              <NiSecondaryButton title='Terminer' onPress={() => requestPermission(false)} style={styles.button} />}
             {state.startHourStamped &&
-              <NiPrimaryButton title='Terminer' onPress={() => startTimeStamping(false)} style={styles.button} />}
+              <NiPrimaryButton title='Terminer' onPress={() => requestPermission(false)} style={styles.button} />}
           </>}
       </View>
     </View>

--- a/src/components/TimeStampingCell/index.tsx
+++ b/src/components/TimeStampingCell/index.tsx
@@ -1,11 +1,13 @@
-import React, { useEffect, useReducer } from 'react';
-import { View, Text } from 'react-native';
+import React, { useEffect, useReducer, useState } from 'react';
+import { View, Text, Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
+import { Camera } from 'expo-camera';
 import { Feather } from '@expo/vector-icons';
 import { formatTime } from '../../core/helpers/dates';
-import { CIVILITY_OPTIONS, TIMESTAMPING_ACTION_TYPE_LIST } from '../../core/data/constants';
+import { CIVILITY_OPTIONS, TIMESTAMPING_ACTION_TYPE_LIST, GRANTED } from '../../core/data/constants';
 import styles from './styles';
 import { EventType, EventHistoryType } from '../../types/EventType';
+import CameraAccessModal from '../../components/modals/CameraAccessModal';
 import NiPrimaryButton from '../form/PrimaryButton';
 import NiSecondaryButton from '../form/SecondaryButton';
 import { WHITE } from '../../styles/colors';
@@ -71,6 +73,9 @@ interface TimeStampingProps {
 
 const TimeStampingCell = ({ event }: TimeStampingProps) => {
   const [state, dispatch] = useReducer(reducer, initialState);
+  const [hasPermission, setHasPermission] = useState<boolean>(false);
+  const [modalVisible, setModalVisible] = useState<boolean>(false);
+
   const navigation = useNavigation();
 
   useEffect(() => { if (event) dispatch({ type: SET_EVENT_INFOS, payload: { event } }); }, [event]);
@@ -95,8 +100,43 @@ const TimeStampingCell = ({ event }: TimeStampingProps) => {
     { event: { _id: event._id, customer: { _id: event.customer._id, identity: event.customer.identity } }, eventStart }
   );
 
+  const requestPermission = async () => {
+    let { status } = await Camera.getPermissionsAsync();
+
+    if (status !== GRANTED) {
+      const { status: newStatus } = await Camera.requestCameraPermissionsAsync();
+      status = newStatus;
+    }
+
+    setModalVisible(status !== GRANTED);
+    setHasPermission(status === GRANTED);
+  };
+
+  const askPermissionAgain = async () => {
+    const permission = await Camera.requestCameraPermissionsAsync();
+
+    if (!permission.canAskAgain) {
+      await Alert.alert(
+        'Accès refusé',
+        'Vérifiez que l\'application a bien l\'autorisation d\'accéder à l\'appareil photo.',
+        [{ text: 'OK', onPress: () => setModalVisible(false) }], { cancelable: false }
+      );
+      return;
+    }
+
+    setModalVisible(permission.status !== GRANTED);
+    setHasPermission(permission.status === GRANTED);
+  };
+
+  const startTimeStamping = async (eventStart: boolean) => {
+    await requestPermission();
+    if (hasPermission) goToBarCodeScanner(eventStart);
+  };
+
   return (
     <View style={styles.cell}>
+      <CameraAccessModal visible={modalVisible} onPressDismiss={() => setModalVisible(false)}
+        onPressAskAgain={askPermissionAgain} />
       <Text style={styles.title}>{CIVILITY_OPTIONS[state.civility]} {state.lastName.toUpperCase()}</Text>
       <View style={styles.sectionDelimiter} />
       <View style={styles.container}>
@@ -108,7 +148,7 @@ const TimeStampingCell = ({ event }: TimeStampingProps) => {
           ? renderTimeStamp()
           : <>
             {!state.endHourStamped &&
-              <NiPrimaryButton title='Commencer' style={styles.button} onPress={() => goToBarCodeScanner(true)} />}
+              <NiPrimaryButton title='Commencer' style={styles.button} onPress={() => startTimeStamping(true)} />}
           </>}
       </View>
       <View style={styles.sectionDelimiter} />
@@ -121,10 +161,9 @@ const TimeStampingCell = ({ event }: TimeStampingProps) => {
           ? renderTimeStamp()
           : <>
             {!state.startHourStamped &&
-              <NiSecondaryButton title='Terminer' onPress={() => goToBarCodeScanner(false)}
-                style={styles.button} />}
+              <NiSecondaryButton title='Terminer' onPress={() => startTimeStamping(false)} style={styles.button} />}
             {state.startHourStamped &&
-              <NiPrimaryButton title='Terminer' onPress={() => goToBarCodeScanner(false)} style={styles.button} />}
+              <NiPrimaryButton title='Terminer' onPress={() => startTimeStamping(false)} style={styles.button} />}
           </>}
       </View>
     </View>

--- a/src/components/modals/CameraAccessModal/index.tsx
+++ b/src/components/modals/CameraAccessModal/index.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
-import { View, Text, TouchableOpacity } from 'react-native';
+import { View, Text } from 'react-native';
 import styles from './styles';
 import NiModal from '../../../components/modals/Modal';
+import PrimaryButton from '../../form/PrimaryButton';
+import SecondaryButton from '../../form/SecondaryButton';
+import modalStyles from '../modalStyles';
 
 interface CameraAccessModalProps {
   visible: boolean,
@@ -12,14 +15,17 @@ interface CameraAccessModalProps {
 const CameraAccessModal = ({ visible, onPressDismiss, onPressAskAgain }: CameraAccessModalProps) => (
   <NiModal visible={visible} style={styles.container}>
     <>
-      <Text style={styles.text}>{'Vous n\'avez pas autorisé l\'accès à la caméra. Veuillez l\'autoriser.'}</Text>
+      <Text style={modalStyles.title}>Accès à la caméra</Text>
+      <Text style={modalStyles.body}>
+        Vous n&apos;avez pas autorisé l&apos;accès à la caméra. Veuillez l&apos;autoriser.
+      </Text>
       <View style={styles.buttonContainer}>
-        <TouchableOpacity onPress={onPressDismiss}>
-          <Text style={styles.buttonText}>{'J\'ai compris'}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity onPress={onPressAskAgain}>
-          <Text style={styles.buttonText}>Redemander</Text>
-        </TouchableOpacity>
+        <View>
+          <SecondaryButton title="J'ai compris" onPress={onPressDismiss} />
+        </View>
+        <View>
+          <PrimaryButton title="Redemander" onPress={onPressAskAgain} />
+        </View>
       </View>
     </>
   </NiModal>

--- a/src/components/modals/CameraAccessModal/index.tsx
+++ b/src/components/modals/CameraAccessModal/index.tsx
@@ -13,7 +13,7 @@ interface CameraAccessModalProps {
 }
 
 const CameraAccessModal = ({ visible, onPressDismiss, onPressAskAgain }: CameraAccessModalProps) => (
-  <NiModal visible={visible} style={styles.container}>
+  <NiModal visible={visible}>
     <>
       <Text style={modalStyles.title}>Accès à la caméra</Text>
       <Text style={modalStyles.body}>

--- a/src/components/modals/CameraAccessModal/styles.ts
+++ b/src/components/modals/CameraAccessModal/styles.ts
@@ -8,7 +8,7 @@ export default StyleSheet.create({
     padding: PADDING.XL,
   },
   text: {
-    ...FIRA_SANS_REGULAR.SM,
+    ...FIRA_SANS_REGULAR.MD,
   },
   buttonContainer: {
     justifyContent: 'space-between',

--- a/src/components/modals/CameraAccessModal/styles.ts
+++ b/src/components/modals/CameraAccessModal/styles.ts
@@ -1,17 +1,14 @@
 import { StyleSheet } from 'react-native';
 import { PINK } from '../../../styles/colors';
-import { MARGIN, PADDING } from '../../../styles/metrics';
+import { MARGIN } from '../../../styles/metrics';
 import { FIRA_SANS_REGULAR } from '../../../styles/fonts';
 
 export default StyleSheet.create({
-  container: {
-    padding: PADDING.XL,
-  },
   text: {
     ...FIRA_SANS_REGULAR.MD,
   },
   buttonContainer: {
-    justifyContent: 'space-between',
+    justifyContent: 'space-around',
     flexDirection: 'row',
     marginTop: MARGIN.XL,
   },

--- a/src/components/modals/modalStyles.ts
+++ b/src/components/modals/modalStyles.ts
@@ -6,7 +6,7 @@ export default StyleSheet.create({
   title: {
     ...FIRA_SANS_BOLD.LG,
     textAlign: 'center',
-    margin: MARGIN.LG,
+    margin: MARGIN.MD,
     fontSize: 20,
   },
   body: {


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [ ] J'ai testé sur android

- [x] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui parce que
  - Non parce que

- [ ] Je n'envoie pas de nouveau paramètre dans une route -np
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite:
- [ ] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas -np
- [ ] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas. -np
- [x] Je n'ai pas changé de constante

- J'ai ajouté une variable d'environnement : -np
  - [ ] Je l'ai ajouté dans env.dev et env.prod aussi

- Cas d'usage : Lorsque l'utilisateur veut horodater un évènement, il faut que l'accès a la camera soit autorisé. Apres appui sur le bouton commencer ou terminer pour horodater le debut ou la fin d'une intervention: 

  - si l'acces a l'appareil photo est autorisé: l'utilisateur est redirigé vers la page d'horodatage par QR Code
  - si l'acces a l'appareil photo n'est pas autorisé: 
        - affichage de la modale "Vous n'avez pas autorisé l'accès à la camera..."
        - dans réglages: accepter l'accès a l'appareil photo
        - commencer/ terminer l'intervention --> la modale de permission d'accès a l'appareil photo apparait  
            - si refus d'accès --> la modale   "Vous n'avez pas autorisé l'accès à la camera..." apparait
            - si autorisation d'accès --> la modale se ferme et il faut rappuyer sur le bouton `Commencer` ou `Terminer` pour horodater 
