### PR TITLE
COM-2466 - Allow time stamping if time stamped event had its time stamp cancelled

### DIFF
--- a/src/components/TimeStampingCell/index.tsx
+++ b/src/components/TimeStampingCell/index.tsx
@@ -83,17 +83,13 @@ const TimeStampingCell = ({ event }: TimeStampingProps) => {
   useEffect(() => {
     if (event.histories) {
       const timeStampingHistories = event.histories
-        .filter((h: EventHistoryType) => TIMESTAMPING_ACTION_TYPE_LIST.includes(h.action));
+        .filter((h: EventHistoryType) => TIMESTAMPING_ACTION_TYPE_LIST.includes(h.action) && !h.isCancelled);
 
       dispatch({
         type: SET_TIMESTAMPED_INFOS,
         payload: {
-          startHourStamped: timeStampingHistories?.some(
-            (h: EventHistoryType) => !!h.update.startHour && !h.isCancelled
-          ) || false,
-          endHourStamped: timeStampingHistories?.some(
-            (h: EventHistoryType) => !!h.update.endHour && !h.isCancelled
-          ) || false,
+          startHourStamped: timeStampingHistories?.some((h: EventHistoryType) => !!h.update.startHour) || false,
+          endHourStamped: timeStampingHistories?.some((h: EventHistoryType) => !!h.update.endHour) || false,
         },
       });
     }

--- a/src/types/EventType.ts
+++ b/src/types/EventType.ts
@@ -18,5 +18,5 @@ export type EventType = {
 export type EventHistoryType = {
   action: string,
   update: { startHour?: Date, endHour?: Date },
-  isCancelled?: boolean,
+  isCancelled: boolean,
 };


### PR DESCRIPTION
- [x] J'ai testé sur iphone
- [x] J'ai testé sur android

- [ ] La nouvelle version de l'app est compatible avec l'ancienne version de l'API ? (J'ai teste en me mettant sur
  master en api)
  - Oui parce que la PR ne dépend pas du back mais j'ai corrigé un bug dedans
  - ~~Non parce que~~

- ~~[ ] Je n'envoie pas de nouveau paramètre dans une route~~
    - Si j'en envoie un nouveau, explication et gestion de la compatibilite:
- ~~[ ] J'attends un nouveau champs en retour de l'api: j'ai géré le cas où il n'y est pas~~
- ~~[ ] J'appelle une nouvelle route: j'ai géré le cas ou la route n'existe pas.~~
- [x] Je n'ai pas changé de constante

- ~~J'ai ajouté une variable d'environnement :~~
  - [ ] Je l'ai ajouté dans env.dev et env.prod aussi

- Cas d'usage :
Lorsqu'un horodatage est annulé sur le planning, je peux l'horodater de nouveau sur l'app
